### PR TITLE
feature/add autofocus plugin

### DIFF
--- a/src/plugins/autofocusPlugin/autofocusPlugin.js
+++ b/src/plugins/autofocusPlugin/autofocusPlugin.js
@@ -1,0 +1,17 @@
+function autofocusPlugin() {
+	return function(fp) {
+		return {
+			onReady (){
+				const autofocus = fp.input.autofocus;
+				if (fp.config.altInput && autofocus) {
+					fp.input.removeAttribute("autofocus");
+					fp.altInput.autofocus = autofocus;
+					fp.altInput.focus();
+				}
+			}
+		}
+	}
+}
+
+if (typeof module !== "undefined")
+	module.exports = autofocusPlugin;


### PR DESCRIPTION
https://jsfiddle.net/escapedcat/bexk4t6c/

I needed the `altInput` option to support the `autofocus` attribute if set on the main input. Looking at the labelPlugin I thought this would be a way to do it.
Let me know if this is ok or if this shouldn't be in here.

Thanks!