### PR TITLE
Log an error when rangePlugin is used without disableMobile enabled

### DIFF
--- a/src/__tests__/rangePlugin.spec.ts
+++ b/src/__tests__/rangePlugin.spec.ts
@@ -19,12 +19,47 @@ const createInstance = (config?: Options): Instance => {
 };
 
 describe("rangePlugin", () => {
+  describe("with the disableMobile option disabled (the flatpickr default)", () => {
+    it("records an error", () => {
+      const errorHandler = jest.fn();
+      const secondInput = document.createElement("input");
+
+      createInstance({
+        plugins: [rangePlugin({ input: secondInput })],
+        defaultDate: ["2017-10-20", "2017-10-25"],
+        dateFormat: "Y-m-d",
+        disableMobile: false,
+        errorHandler,
+      }) as RangeInstance;
+
+      expect(errorHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe("with the disableMobile option enabled", () => {
+    it("doesn't record an error", () => {
+      const errorHandler = jest.fn();
+      const secondInput = document.createElement("input");
+
+      createInstance({
+        plugins: [rangePlugin({ input: secondInput })],
+        defaultDate: ["2017-10-20", "2017-10-25"],
+        dateFormat: "Y-m-d",
+        disableMobile: true,
+        errorHandler,
+      }) as RangeInstance;
+
+      expect(errorHandler).not.toHaveBeenCalled();
+    });
+  });
+
   it("should correctly preload defaultDate", () => {
     const secondInput = document.createElement("input");
     const fp = createInstance({
       plugins: [rangePlugin({ input: secondInput })],
       defaultDate: ["2017-10-20", "2017-10-25"],
       dateFormat: "Y-m-d",
+      disableMobile: true,
     }) as RangeInstance;
 
     expect(fp.selectedDates.length).toEqual(2);

--- a/src/plugins/rangePlugin.ts
+++ b/src/plugins/rangePlugin.ts
@@ -12,6 +12,16 @@ declare global {
 
 function rangePlugin(config: Config = {}) {
   return function(fp: Instance) {
+    if (!fp.config.disableMobile) {
+      fp.config.errorHandler(
+        new Error(
+          "WARNING! rangePlugin will not work on mobile devices unless " +
+            "flatpickr's disableMobile option is enabled. For more details, see " +
+            "https://chmln.github.io/flatpickr/mobile-support/."
+        )
+      );
+    }
+
     let dateFormat = "",
       secondInput: HTMLInputElement,
       _firstInputFocused: boolean,
@@ -23,7 +33,7 @@ function rangePlugin(config: Config = {}) {
         secondInput =
           config.input instanceof Element
             ? config.input
-            : window.document.querySelector(config.input) as HTMLInputElement;
+            : (window.document.querySelector(config.input) as HTMLInputElement);
       } else {
         secondInput = fp._input.cloneNode() as HTMLInputElement;
         secondInput.removeAttribute("id");
@@ -132,10 +142,9 @@ function rangePlugin(config: Config = {}) {
           _prevDates = [...newDates];
         }
 
-        [
-          fp._input.value = "",
-          secondInput.value = "",
-        ] = fp.selectedDates.map(d => fp.formatDate(d, dateFormat));
+        [fp._input.value = "", secondInput.value = ""] = fp.selectedDates.map(
+          d => fp.formatDate(d, dateFormat)
+        );
       },
     };
 


### PR DESCRIPTION
`rangePlugin` doesn't actually work when you don't have `disableMobile` enabled, so we should try to inform users. I'll follow this up with a PR to the docs.