### PR TITLE
fix(typings): use correct default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,4 +35,4 @@ declare namespace flatpickr {
   }
 }
 
-export = flatpickr;
+export default flatpickr;


### PR DESCRIPTION
Hi there! After 4.2.1 which adds the default module export, typescript users have to change the flatpickr import from:
```
import * as flatpickr from 'flatpickr';
```
to
```
import flatpickr from 'flatpickr';
```

However, the typings don't match up to this and the typescript compiler complains with "flatpickr has no default export", unless you set `allowSyntheticDefaultImports` in your tsconfig. This small change aligns the typings with the actual module shape and should avoid these types of errors for people so they can use it with typescript with no friction.