### PR TITLE
onMonthNavClick use classList in condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2363,9 +2363,9 @@ function FlatpickrInstance(
       changeMonth(isPrevMonth ? -1 : 1);
     } else if (e.target === self.currentYearElement) {
       self.currentYearElement.select();
-    } else if ((e.target as Element).className === "arrowUp") {
+    } else if ((e.target as Element).classList.contains("arrowUp")) {
       self.changeYear(self.currentYear + 1);
-    } else if ((e.target as Element).className === "arrowDown") {
+    } else if ((e.target as Element).classList.contains("arrowDown")) {
       self.changeYear(self.currentYear - 1);
     }
   }


### PR DESCRIPTION
In out application, we use a namespaced stylesheet. I've managed to solve for this issue by adding a namespaced class to each of the flatpickr elements in the onShow hook. Here's what happens...

this....
`
<span class="arrowUp"></span>
`
becomes...
`
<span class="arrowUp node-1234-arrowUp"></span>
`

All the styling is applied perfectly, but the up and down year selector arrows don't functions because a condition expects a specific value for the class attribute. My pull request solves for this issue. Also, my code change is more inline with other conventions in your code.

Thanks!



