### PR TITLE
Add new option to allow clear input by press key `backspace` or `delete`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1380,7 +1380,11 @@ function FlatpickrInstance(
 
         case 8:
         case 46:
-          if (isInput && !self.config.allowInput) {
+          if (
+            isInput &&
+            !self.config.allowInput &&
+            self.config.allowClearInput
+          ) {
             e.preventDefault();
             self.clear();
           }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -38,6 +38,9 @@ export interface BaseOptions {
   */
   allowInput: boolean;
 
+  /* Allows the user to clear input with backspace or delete key. By default is enabled. */
+  allowClearInput: boolean;
+
   /* Exactly the same as date format, but for the altInput field */
   altFormat: string;
 
@@ -238,6 +241,7 @@ export interface ParsedOptions {
   _minDate?: Date;
   _minTime?: Date;
   allowInput: boolean;
+  allowClearInput: boolean;
   altFormat: string;
   altInput: boolean;
   altInputClass: string;
@@ -301,6 +305,7 @@ export const defaults: ParsedOptions = {
   _disable: [],
   _enable: [],
   allowInput: false,
+  allowClearInput: true,
   altFormat: "F j, Y",
   altInput: false,
   altInputClass: "form-control input",


### PR DESCRIPTION
For some cases(business logic), clearing input by press keys `backspace` or `delete` should be blocked when `config.allowInput = false`.