### PR TITLE
Revert default export typings

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -35,4 +35,4 @@ declare namespace flatpickr {
   }
 }
 
-export default flatpickr;
+export = flatpickr;


### PR DESCRIPTION
Hello! After https://github.com/flatpickr/flatpickr/commit/10b33ca3a08cc597bce858245620a10250cd18d1 the typings now no longer match up to the shape of the imported typescript object. i.e. to use this module typescript users now have to do

```
import * as flatpickr from 'flatpickr';
```

Instead of 
```
import flatpickr from 'flatpickr';
```

This changes the declaration to match this change. 

Alternatively, to go back to the old behaviour `output.exports` in the rollup config needs to be set to `named` instead of `default` as it is now. 