### PR TITLE
Fix init on mobile with enabled confirmDatePlugin

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2,6 +2,7 @@ import flatpickr from "../index";
 import { Russian } from "../l10n/ru";
 import { Instance, DayElement } from "../types/instance";
 import { Options, DateRangeLimit } from "../types/options";
+import confirmDatePlugin from '../plugins/confirmDate/confirmDate';
 
 flatpickr.defaultConfig.animate = false;
 flatpickr.defaultConfig.closeOnSelect = true;
@@ -821,6 +822,13 @@ describe("flatpickr", () => {
           expect(mobileInput.disabled).toBe(true);
           expect(mobileInput.required).toBe(true);
         });
+
+        it('with confirmDatePlugin', () => {
+          mockAgent = 'Android';
+          createInstance({
+            plugins: [confirmDatePlugin({})]
+          });
+        })
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1853,6 +1853,17 @@ function FlatpickrInstance(
       self.config.enableTime = true;
     }
 
+    self.isMobile =
+      !self.config.disableMobile &&
+      !self.config.inline &&
+      self.config.mode === "single" &&
+      !self.config.disable.length &&
+      !self.config.enable.length &&
+      !self.config.weekNumbers &&
+      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent
+      );
+
     for (let i = 0; i < self.config.plugins.length; i++) {
       const pluginConf = self.config.plugins[i](self) || ({} as Options);
       for (const key in pluginConf) {
@@ -1868,17 +1879,6 @@ function FlatpickrInstance(
           ] as any;
       }
     }
-
-    self.isMobile =
-      !self.config.disableMobile &&
-      !self.config.inline &&
-      self.config.mode === "single" &&
-      !self.config.disable.length &&
-      !self.config.enable.length &&
-      !self.config.weekNumbers &&
-      /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      );
 
     triggerEvent("onParseConfig");
   }


### PR DESCRIPTION
Problem: Initialization for mobile with enabled confirmDatePlugin cause an exception, due to plugin expect property `isMobile` that setuped after plugins initialization.

Solution: setup isMobile before initialize plugins.

- [x] update test to "red"
- [x] fix problem