### PR TITLE
Always `preventDefault()` event in `onMonthNavClick`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2463,13 +2463,14 @@ function FlatpickrInstance(
   }
 
   function onMonthNavClick(e: MouseEvent) {
+    e.preventDefault();
+
     const isPrevMonth = self.prevMonthNav.contains(e.target as Node);
     const isNextMonth = self.nextMonthNav.contains(e.target as Node);
 
     if (isPrevMonth || isNextMonth) {
       changeMonth(isPrevMonth ? -1 : 1);
     } else if (self.yearElements.indexOf(e.target as HTMLInputElement) >= 0) {
-      e.preventDefault();
       (e.target as HTMLInputElement).select();
     } else if ((e.target as Element).classList.contains("arrowUp")) {
       self.changeYear(self.currentYear + 1);


### PR DESCRIPTION
> By always preventing the default event in onMonthNavClick no unwanted focus events get handled which caused faltpicker to immediately close in e.g. a BS modal.

#1240 Fixed this already but it was reintroduced in #1202.

This closes #1330, #1332.