### PR TITLE
 Swap placeholder length check with not-null & empty check.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2259,8 +2259,8 @@ function FlatpickrInstance(
     // Workaround IE11 setting placeholder as the input's value
     const preloadedDate =
       self.config.defaultDate ||
-      (self.input.placeholder.length > 0 &&
-      self.input.value === self.input.placeholder
+      (self.input.placeholder
+        && self.input.value === self.input.placeholder
         ? null
         : self.input.value);
 


### PR DESCRIPTION
This PR fixes #1378.

The ternary predicate will now also return as falsy if `self.input.placeholder` is null or undefined.
This prevents the check from throwing an error if `self.input` is something other than an `input` element (e.g. buttons), as mentioned in #1378.