### PR TITLE
Fix for #1412:  Incorrect Month Label when Toggling Mode from "multip…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -934,6 +934,11 @@ function FlatpickrInstance(
     clearNode(self.monthNav);
     self.monthNav.appendChild(self.prevMonthNav);
 
+    if (self.config.showMonths) {
+      self.yearElements = [];
+      self.monthElements = [];
+    }
+
     for (let m = self.config.showMonths; m--; ) {
       const month = buildMonth();
       self.yearElements.push(month.yearElement);


### PR DESCRIPTION
Fix for #1412:  Incorrect Month Label when Toggling Mode from "multiple" to "range" (and "showMonths" is in the calendar's config)