### PR TITLE
Fix `data-toggle` button on mobile for real...

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1709,9 +1709,10 @@ function FlatpickrInstance(
         e.target && (e.target as HTMLInputElement).blur();
       }
 
-      setTimeout(() => {
-        self.mobileInput !== undefined && self.mobileInput.focus();
-      }, 0);
+      if (self.mobileInput !== undefined) {
+        self.mobileInput.focus();
+        self.mobileInput.click();
+      }
 
       triggerEvent("onOpen");
       return;


### PR DESCRIPTION
This is a follow-up to #1285 and fixes the `mobileInput` event triggering for iOS and Android.

See this demo for confirmation:
https://codesandbox.io/s/9ojvmwvxxo