### PR TITLE
make sure active element is not null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -787,7 +787,7 @@ function FlatpickrInstance(
   }
 
   function focusOnDay(current: DayElement | undefined, offset: number) {
-    const dayFocused = isInView(document.activeElement);
+    const dayFocused = isInView(document.activeElement || document.body);
     const startElem =
       current !== undefined
         ? current


### PR DESCRIPTION
**What's Changed?**
Added a check if there is no element selected in IE (document.activeElement is null) it will pass the body element to dayFocused.

**How To Test**
In Internet Explorer, use the keyboard to select dates in a month outside of the currently selected month.  Use Control + up/down/left/right cursors to change month and year

**Notes**
Chrome, Firefox and Safari will return the body element as document.activeElement if nothing is selected but Internet Explorer 11 will return null

