### PR TITLE
Prevent error due to onChange firing after destroy() is called

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2443,6 +2443,9 @@ function FlatpickrInstance(
   }
 
   function triggerEvent(event: HookKey, data?: any) {
+    // If the instance has been destroyed already, all hooks have been removed
+    if (self.config === undefined) return;
+
     const hooks = self.config[event];
 
     if (hooks !== undefined && hooks.length > 0) {


### PR DESCRIPTION
If `destroy()` is called on a flatpickr instance after it closes but before the 300ms `onChange` timeout, then `triggerEvent` will throw an error when it eventually looks for `onChange` hooks, because `destroy()` removes the config. This PR fixes that problem.