### PR TITLE
Handle focus when tabbing out of flatpickr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1552,7 +1552,10 @@ function FlatpickrInstance(
           break;
 
         case 9:
-          if (!isTimeObj) break;
+          if (!isTimeObj) {
+            self.element.focus();
+            break;
+          }
           const elems = [
             self.hourElement,
             self.minuteElement,
@@ -1567,6 +1570,8 @@ function FlatpickrInstance(
             if (target !== undefined) {
               e.preventDefault();
               target.focus();
+            } else {
+              self.element.focus();
             }
           }
 


### PR DESCRIPTION
What's Changed?
Added to the handler for tab event so if you tab off flatpickr it will refocus your input element instead of jumping to the beginning of the DOM

How To Test
1. Add some links to the page before and after your input element so you can track the focus
2. Open flatpickr with a calendar
3. Use the cursors to navigate
4. Press tab.  You'll now end up at the next element on the page instead of at the top of the page

also

1. Open flatpickr with noCalendar: true and enableTime: true
2. Set a time, press tab past the AM/PM
3. You'll now end up at the next element on the page.

Notes
Issue #1236 says the desired behaviour for time only would be that tab would loop through hour/minute/am-pm but I would prefer it close flatpickr as it currently does.