### PR TITLE
Fix wrong path for types

### DIFF
--- a/emitDeclarations.sh
+++ b/emitDeclarations.sh
@@ -8,3 +8,4 @@ else
 fi
 cp src/typings.d.ts dist/typings.d.ts
 rm -rf types
+find dist/types/l10n/ -type f -iname '*.d.ts' -exec sed -i '' -e 's#"types/locale"#"../types/locale"#g' "{}" +;


### PR DESCRIPTION
The correct paths can't be found because we don't just export the language definition, but always merge it with existing ones on `window` and export the result. This is something that is likely never supported well in TypeScript. For now I think a simple addition to the `build:post` step suffices.

Fixes #1440