### PR TITLE
prevent error on destroy if wrapper has no parent node, restore keyboard control for time on datetime picker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1541,7 +1541,7 @@ function FlatpickrInstance(
           e.preventDefault();
           const delta = e.keyCode === 40 ? 1 : -1;
 
-          if (self.daysContainer) {
+          if (self.daysContainer && (e.target as DayElement).$i !== undefined) {
             if (e.ctrlKey) {
               changeYear(self.currentYear - delta);
               focusOnDay(getFirstAvailableDay(1), 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1245,9 +1245,12 @@ function FlatpickrInstance(
       if (self.config.static && self.calendarContainer.parentNode) {
         const wrapper = self.calendarContainer.parentNode;
         wrapper.lastChild && wrapper.removeChild(wrapper.lastChild);
-        while (wrapper.firstChild)
-          wrapper.parentNode!.insertBefore(wrapper.firstChild, wrapper);
-        wrapper.parentNode!.removeChild(wrapper);
+
+        if (wrapper.parentNode) {
+          while (wrapper.firstChild)
+            wrapper.parentNode!.insertBefore(wrapper.firstChild, wrapper);
+          wrapper.parentNode!.removeChild(wrapper);
+        }
       } else
         self.calendarContainer.parentNode.removeChild(self.calendarContainer);
     }


### PR DESCRIPTION
In my project, we are using flatpickr in such a way that we create "virtual" instances whose wrappers aren't actually inserted into the DOM. In the current code, this throws an error when `destroy` is called because it tries to remove children on the parent node's wrapper.

This just adds a simple check to prevent that error in case the wrapper has no parent.

Also, I noticed that with a datetime picker you can no longer change the time with the arrow keys. I restored an earlier piece of deleted code that restores this functionality.