### PR TITLE
Avoid use of child nodes for browser support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -901,7 +901,9 @@ function FlatpickrInstance(
 
     const yearInput = createNumberInput("cur-year", { tabindex: "-1" });
 
-    const yearElement = yearInput.childNodes[0] as HTMLInputElement;
+    const yearElement = yearInput.getElementsByTagName(
+      "input"
+    )[0] as HTMLInputElement;
     yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
 
     if (self.config.minDate)
@@ -1005,10 +1007,14 @@ function FlatpickrInstance(
     const separator = createElement("span", "flatpickr-time-separator", ":");
 
     const hourInput = createNumberInput("flatpickr-hour");
-    self.hourElement = hourInput.childNodes[0] as HTMLInputElement;
+    self.hourElement = hourInput.getElementsByTagName(
+      "input"
+    )[0] as HTMLInputElement;
 
     const minuteInput = createNumberInput("flatpickr-minute");
-    self.minuteElement = minuteInput.childNodes[0] as HTMLInputElement;
+    self.minuteElement = minuteInput.getElementsByTagName(
+      "input"
+    )[0] as HTMLInputElement;
 
     self.hourElement.tabIndex = self.minuteElement.tabIndex = -1;
 
@@ -1057,7 +1063,9 @@ function FlatpickrInstance(
       self.timeContainer.classList.add("hasSeconds");
 
       const secondInput = createNumberInput("flatpickr-second");
-      self.secondElement = secondInput.childNodes[0] as HTMLInputElement;
+      self.secondElement = secondInput.getElementsByTagName(
+        "input"
+      )[0] as HTMLInputElement;
 
       self.secondElement.value = pad(
         self.latestSelectedDateObj


### PR DESCRIPTION
What's Changed?
No functional changes. Using a different selector to get the same element.

How To Test
Test the year input on date picker and minutes/hours/seconds on time picker. 

Notes
I wasn't able to reproduce the problem but it's related to issue https://github.com/flatpickr/flatpickr/issues/1457 . Possibly something is adding unnecessary whitespace. According to stack overflow, "Some browsers include empty textNodes, some do not"

