### PR TITLE
Fix cursor problems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1537,6 +1537,7 @@ function FlatpickrInstance(
 
               if (!e.ctrlKey) focusOnDay(undefined, delta);
               else {
+                e.stopPropagation();
                 changeMonth(delta);
                 focusOnDay(getFirstAvailableDay(1), 0);
               }
@@ -1549,9 +1550,12 @@ function FlatpickrInstance(
         case 40:
           e.preventDefault();
           const delta = e.keyCode === 40 ? 1 : -1;
-
-          if (self.daysContainer && (e.target as DayElement).$i !== undefined) {
+          if (
+            (self.daysContainer && (e.target as DayElement).$i !== undefined) ||
+            e.target === self.input
+          ) {
             if (e.ctrlKey) {
+              e.stopPropagation();
               changeYear(self.currentYear - delta);
               focusOnDay(getFirstAvailableDay(1), 0);
             } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
@@ -1612,7 +1616,6 @@ function FlatpickrInstance(
           break;
       }
     }
-
     triggerEvent("onKeyDown", e);
   }
 


### PR DESCRIPTION
What's Changed?
* Added an OR to solve the issue of pressing up/down cursors when the input is still the active element (flatpickr was just opened)
* Added a e.stopPropagation() to prevent jumping 2 years the first time you press ctrl+up or 2 months the first time you press ctrl+right

How To Test
Try cursor keys with default options, try with enableTime: true and with noCalendar: true

Notes
Relates to https://github.com/flatpickr/flatpickr/pull/1461
