### PR TITLE
Initialize with default value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1537,6 +1537,7 @@ function FlatpickrInstance(
 
               if (!e.ctrlKey) focusOnDay(undefined, delta);
               else {
+                e.stopPropagation();
                 changeMonth(delta);
                 focusOnDay(getFirstAvailableDay(1), 0);
               }
@@ -1549,9 +1550,12 @@ function FlatpickrInstance(
         case 40:
           e.preventDefault();
           const delta = e.keyCode === 40 ? 1 : -1;
-
-          if (self.daysContainer && (e.target as DayElement).$i !== undefined) {
+          if (
+            (self.daysContainer && (e.target as DayElement).$i !== undefined) ||
+            e.target === self.input
+          ) {
             if (e.ctrlKey) {
+              e.stopPropagation();
               changeYear(self.currentYear - delta);
               focusOnDay(getFirstAvailableDay(1), 0);
             } else if (!isTimeObj) focusOnDay(undefined, delta * 7);
@@ -1612,7 +1616,6 @@ function FlatpickrInstance(
           break;
       }
     }
-
     triggerEvent("onKeyDown", e);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2284,9 +2284,9 @@ function FlatpickrInstance(
       ((self.input.nodeName === "INPUT" ||
         self.input.nodeName === "TEXTAREA") &&
       self.input.placeholder &&
-      self.input.value === self.input.placeholder
+      self.input.defaultValue === self.input.placeholder
         ? null
-        : self.input.value);
+        : self.input.defaultValue);
 
     if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
 


### PR DESCRIPTION
What's Changed?
Initialize with defaultValue (value attribute) instead of value

How To Test
Initialize flatpickr on an input that has already been initialized.
Also try using destroy() and reinitialize:
  const fp = flatpickr(".date", {
  });
  fp.destroy()
  flatpickr(".date", {
  });
The second time it will clear the date and you can't get it back.

Notes
This is related to issue https://github.com/flatpickr/flatpickr/issues/1148
