### PR TITLE
fix: focus datepicker when self.open() is called

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1749,6 +1749,8 @@ function FlatpickrInstance(
       self._input.classList.add("active");
       triggerEvent("onOpen");
       positionCalendar(positionElement);
+      self.calendarContainer.focus();
+      focusOnDay(undefined, 0);
     }
 
     if (self.config.enableTime === true && self.config.noCalendar === true) {


### PR DESCRIPTION
**The problem**
When I manually trigger the opening of the picker, I want it to be focused on the current date so that keyboard users can immediately navigate.

My use-case is that I have a little datepicker button that a user can click to open the datepicker on the side of my input.
![image](https://user-images.githubusercontent.com/3859574/45407208-1784a800-b6ac-11e8-9d23-8b5bc9424f1e.png)

**The solution**
If the active element isn't in view, focus on the current date. This might need a bit of adjustment for correctness, but I'm happy to make changes as required.

**Side benefits**
- I also trigger the opening of the calendar manually if a user presses ArrowDown whilst focused on the <input>, this input is also using `allowInput: true` in the configuration. This allows me to use keyboard navigation again. (before doing this fix, keyboard navigation didn't seem to work)

**Workaround using hooks**
I was able to achieve the same behaviour by using the `onOpen` config so that it focuses on the calendar when it's opened.

This was not tested with the mobile codepath however, which calls the same trigger.

```js
private flatpickr?: flatpickr.Instance;

private onOpen = (): void => {
	if (this.flatpickr) {
		// NOTE(Jake): 2018-09-13
		// This focuses the calendar if its not currently focused.
		//
		// This is a workaround until this PR gets merged:
		// https://github.com/flatpickr/flatpickr/pull/1503
		//
		if (this.flatpickr.calendarContainer &&
			!this.flatpickr.calendarContainer.contains(document.activeElement)) {
			if (document.activeElement === this.flatpickr._input) {
				// NOTE(Jake): 2018-09-13
				// This if-statement / blur() is needed, otherwise when
				// you open a picker with ArrowDown key, you can't use keyboard
				// navigation with the picker.
				this.flatpickr._input.blur();
			}
			this.flatpickr.selectedDateElem.focus();
		}
	}
}
```