### PR TITLE
Fix Latvian language translation

### DIFF
--- a/src/l10n/lv.ts
+++ b/src/l10n/lv.ts
@@ -13,7 +13,7 @@ export const Latvian: CustomLocale = {
   firstDayOfWeek: 1,
 
   weekdays: {
-    shorthand: ["Sv", "P", "Ot", "Tr", "Ce", "Pk", "Se"],
+    shorthand: ["Sv", "Pr", "Ot", "Tr", "Ce", "Pk", "Se"],
     longhand: [
       "Svētdiena",
       "Pirmdiena",
@@ -30,8 +30,8 @@ export const Latvian: CustomLocale = {
       "Jan",
       "Feb",
       "Mar",
-      "Mai",
       "Apr",
+      "Mai",
       "Jūn",
       "Jūl",
       "Aug",


### PR DESCRIPTION
1. Make all short day name consist of 2 letters
2. Fix mixed April and May short month names