### PR TITLE
Fixed error when the datepicker is destroyed before it is initialized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,10 @@ function FlatpickrInstance(
     if (config.weekNumbers === false && config.showMonths === 1) return;
     else if (config.noCalendar !== true) {
       window.requestAnimationFrame(function() {
-        self.calendarContainer.style.visibility = "hidden";
-        self.calendarContainer.style.display = "block";
+        if (self.calendarContainer !== undefined) {
+          self.calendarContainer.style.visibility = "hidden";
+          self.calendarContainer.style.display = "block";
+        }
         if (self.daysContainer !== undefined) {
           const daysWidth = (self.days.offsetWidth + 1) * config.showMonths;
 


### PR DESCRIPTION
In some edge case I saw an error in the console (I'm using flatpickr in combination with react-flatpickr).

```Uncaught TypeError: Cannot read property 'style' of undefined```

It was caused by an unmount which happened very fast after the mount. Therefore the init logic of flatpickr was not completely finished. This change should fix this.