### PR TITLE
Loosen type requirements & fix empty set handling

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -79,6 +79,10 @@ describe("flatpickr", () => {
   beforeEach(beforeEachTest);
 
   describe("init", () => {
+    it("should gracefully handle no elements", () => {
+      expect(flatpickr([])).toEqual([]);
+    });
+
     it("should parse defaultDate", () => {
       createInstance({
         defaultDate: "2016-12-27T16:16:22.585Z",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2675,8 +2675,8 @@ function _flatpickr(
   nodeList: ArrayLike<Node>,
   config?: Options
 ): Instance | Instance[] {
-  // spare ourselves some cycles & errors
-  if (nodeList == null || !nodeList.length) {
+  // spare ourselves some cycles
+  if (nodeList.length === 0) {
     return [];
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2672,10 +2672,19 @@ function FlatpickrInstance(
 
 /* istanbul ignore next */
 function _flatpickr(
-  nodeList: NodeList | HTMLElement[],
+  nodeList: ArrayLike<Node>,
   config?: Options
 ): Instance | Instance[] {
-  const nodes: HTMLElement[] = Array.prototype.slice.call(nodeList); // static list
+  // spare ourselves some cycles & errors
+  if (nodeList == null || !nodeList.length) {
+    return [];
+  }
+
+  // static list
+  const nodes = Array.from(nodeList).filter(
+    x => x instanceof HTMLElement
+  ) as HTMLElement[];
+
   let instances: Instance[] = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -2713,14 +2722,16 @@ if (typeof HTMLElement !== "undefined") {
 
 /* istanbul ignore next */
 var flatpickr = function(
-  selector: NodeList | HTMLElement | string,
+  selector: ArrayLike<Node> | Node | string,
   config?: Options
 ) {
-  if (selector instanceof NodeList) return _flatpickr(selector, config);
-  else if (typeof selector === "string")
+  if (typeof selector === "string") {
     return _flatpickr(window.document.querySelectorAll(selector), config);
-
-  return _flatpickr([selector], config);
+  } else if (selector instanceof Node) {
+    return _flatpickr([selector], config);
+  } else {
+    return _flatpickr(selector, config);
+  }
 } as FlatpickrFn;
 
 /* istanbul ignore next */

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -144,9 +144,9 @@ export type Instance = Elements &
   };
 
 export interface FlatpickrFn {
-  (selector: NodeList | HTMLElement | string, config?: Options):
-    | Instance
-    | Instance[];
+  (selector: Node, config?: Options): Instance;
+  (selector: ArrayLike<Node>, config?: Options): Instance[];
+  (selector: string, config?: Options): Instance | Instance[];
   defaultConfig: ParsedOptions;
   l10ns: { [k in LocaleKey]?: CustomLocale } & { default: Locale };
   localize: (l10n: CustomLocale) => void;


### PR DESCRIPTION
Currently the function constructor only allows a `NodeList` or `HTMLElement`, which is conceptually accurate & successfully captures the majority of usecases. However, there are issues with choosing this implementation:

1) `NodeList` is too restrictive an interface. While it's effectively the same as `NodeListOf<HTMLElement>`, it's definitively *not* the same as `HTMLCollection`, a separately supported interface. Both would be adequately supported by leveraging the built-in `ArrayLike<T>` interface.

2) `HTMLElement` is also, paradoxically, too restrictive an interface. Internally it's necessary to guarantee the object is an `HTMLElement` so we can access `node.getAttribute` inside the `_flatpickr` loop. The trick is, while the outer type "protects" us from this foul, no actual check exists in the code, to the point that the initially failing unit test tricks it into accessing this property merely by passing in an empty array (as `[] instanceof NodeList` is false, we end up with `_flatpickr([[]])`), ensuring that `nodeList[i]` immediately fails. Adding the check while relaxing the allowed outer type (along with some control-flow tweaking) allows a consumer to transparently use DOM APIs that, while typed to return `Node | ArrayLike<Node>`, in practice would satisfy `HTMLElement | ArrayLike<HTMLElement>`.

3) The above is admittedly not an issue if you only intend to support `NodeList` as the collection interface. But.... why tho :confused: :question: 