### PR TITLE
Fix XHTML compatibility of weekday list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1156,8 +1156,8 @@ function FlatpickrInstance(
 
     for (let i = self.config.showMonths; i--; ) {
       self.weekdayContainer.children[i].innerHTML = `
-      <span class=flatpickr-weekday>
-        ${weekdays.join("</span><span class=flatpickr-weekday>")}
+      <span class='flatpickr-weekday'>
+        ${weekdays.join("</span><span class='flatpickr-weekday'>")}
       </span>
       `;
     }


### PR DESCRIPTION
The flatpickr generates following error on XHTML pages when the weekdays are generated:

    DOMException: Failed to set the 'innerHTML' property on 'Element': The provided markup is invalid XML, and therefore cannot be inserted into an XML document.
        at updateWeekdays (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:1114:59)
        at buildWeekdays (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:1101:11)
        at build (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:781:43)
        at init (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:493:15)
        at FlatpickrInstance (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:2197:7)
        at _flatpickr (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:2212:33)
        at flatpickr (https://example.com/ext/flatpickr-4.5.1/flatpickr.js:2234:14)
        at https://example.com/test:197:26

This can be avoided by adding quotes around the argument value.