### PR TITLE
Remove bashisms from emitDeclarations.sh

### DIFF
--- a/emitDeclarations.sh
+++ b/emitDeclarations.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ./node_modules/typescript/bin/tsc -p tsconfig.declarations.json
 os=`uname`
-if [[ "$os" == "Darwin" ]]; then
+if [ "$os" = "Darwin" ]; then
     cp -R types dist
 else
     cp -RT types dist


### PR DESCRIPTION
The script is marked as posix shell script, is started using a posix shell
script but uses bashisms. The script will therefore fail with a posix
shell:

    $ sh ./emitDeclarations.sh
    ./emitDeclarations.sh: 4: ./emitDeclarations.sh: [[: not found
    error Command failed with exit code 127.

But this bashism can easily be replaced with POSIX only code that also
works with bash.