### PR TITLE
Fix IE 11 lack of object.assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,6 +16,7 @@
   ],
   "plugins": [
     ["@babel/plugin-proposal-object-rest-spread", { "useBuiltIns": true }],
-    "@babel/plugin-proposal-optional-catch-binding"
+    "@babel/plugin-proposal-optional-catch-binding",
+    "@babel/plugin-transform-object-assign",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/core": "7.2.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "7.2.3",
     "@types/acorn": "^4.0.4",
     "@types/chokidar": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-object-assign@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz#6fdeea42be17040f119e38e23ea0f49f31968bde"
+  integrity sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-object-super@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"


### PR DESCRIPTION
Typescript will and already generate crossbrowser object.assign implementation.

This pull request will fix IE11 ability to `setDate` and some initial configuration overrides