### PR TITLE
Reset currentMonth and currentYear when clear() is called

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -703,6 +703,10 @@ describe("flatpickr", () => {
         });
 
         fp.changeMonth(-1);
+
+        expect(fp.currentMonth).toEqual(11);
+        expect(fp.currentYear).toEqual(2015);
+
         fp.clear();
 
         expect(fp.currentMonth).toEqual(0);

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -695,6 +695,20 @@ describe("flatpickr", () => {
       expect(fp.isEnabled("2016-10-22")).toBe(false);
       expect(fp.isEnabled("2016-10-25")).toBe(false);
     });
+
+    describe("clear()", () => {
+      it("resets currentMonth and currentYear", () => {
+        createInstance({
+          defaultDate: "2016-01-20",
+        });
+
+        fp.changeMonth(-1);
+        fp.clear();
+
+        expect(fp.currentMonth).toEqual(0);
+        expect(fp.currentYear).toEqual(2016);
+      });
+    });
   });
 
   describe("UI", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1215,6 +1215,8 @@ function FlatpickrInstance(
 
     self.selectedDates = [];
     self.latestSelectedDateObj = undefined;
+    self.currentYear = self._initialDate.getFullYear();
+    self.currentMonth = self._initialDate.getMonth();
     self.showTimeInput = false;
 
     if (self.config.enableTime === true) {
@@ -2338,7 +2340,7 @@ function FlatpickrInstance(
 
     if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
 
-    const initialDate =
+    self._initialDate =
       self.selectedDates.length > 0
         ? self.selectedDates[0]
         : self.config.minDate &&
@@ -2349,8 +2351,8 @@ function FlatpickrInstance(
         ? self.config.maxDate
         : self.now;
 
-    self.currentYear = initialDate.getFullYear();
-    self.currentMonth = initialDate.getMonth();
+    self.currentYear = self._initialDate.getFullYear();
+    self.currentMonth = self._initialDate.getMonth();
 
     if (self.selectedDates.length > 0)
       self.latestSelectedDateObj = self.selectedDates[0];

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -63,6 +63,7 @@ export type Instance = Elements &
     latestSelectedDateObj?: Date;
     _selectedDateObj?: Date;
     selectedDates: Date[];
+    _initialDate: Date;
 
     // State
     config: ParsedOptions;


### PR DESCRIPTION
Resolves #1643 