### PR TITLE
check for altInput on tab off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatpickr",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "A lightweight, powerful javascript datetime picker",
   "scripts": {
     "build": "run-s build:pre build:build build:post",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1607,22 +1607,14 @@ function FlatpickrInstance(
                 e.preventDefault();
                 target.focus();
               } else if (childElementCount <= expectedChildElementCount) {
-                if (self.altInput) {
-                  self.altInput.focus();
-                } else {
-                  self.element.focus();
-                }
+                self._input.focus();
               }
             }
             break;
           }
 
           if (childElementCount <= expectedChildElementCount) {
-            if (self.altInput) {
-              self.altInput.focus();
-            } else {
-              self.element.focus();
-            }
+            self._input.focus();
           }
 
           break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1607,14 +1607,22 @@ function FlatpickrInstance(
                 e.preventDefault();
                 target.focus();
               } else if (childElementCount <= expectedChildElementCount) {
-                self.element.focus();
+                if (self.altInput) {
+                  self.altInput.focus();
+                } else {
+                  self.element.focus();
+                }
               }
             }
             break;
           }
 
           if (childElementCount <= expectedChildElementCount) {
-            self.element.focus();
+            if (self.altInput) {
+              self.altInput.focus();
+            } else {
+              self.element.focus();
+            }
           }
 
           break;


### PR DESCRIPTION
What's Changed?
Fixed issue #1661 when tabbing off flatpickr using altInput

How To Test
1. Add a focusable element before and after the flatpickr input.
2. Tab to the input, tab off again. It should go to the next element, not back to the top

Notes
Tested with 
{
    enableTime: true,
    altFormat: "H:i",
    altInput: true,
    noCalendar: true,
    dateFormat: "H:i",
  }

and

{
    enableTime: true,
    dateFormat: "Y-m-d H:i",
    altInput: true,
    altFormat: "m/d/Y",
  }