### PR TITLE
remove Array.from

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2691,9 +2691,9 @@ function _flatpickr(
   }
 
   // static list
-  const nodes = Array.from(nodeList).filter(
-    x => x instanceof HTMLElement
-  ) as HTMLElement[];
+  const nodes = Array.prototype.slice
+    .call(nodeList)
+    .filter(x => x instanceof HTMLElement) as HTMLElement[];
 
   let instances: Instance[] = [];
   for (let i = 0; i < nodes.length; i++) {


### PR DESCRIPTION
What's Changed?
Removed Array.from method so it'll work in IE (#1662)

How To Test
Try it in IE

Notes
We could do this with a polyfill, but it's a pretty big one, so I would suggest this work around
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill
