### PR TITLE
build(emitDeclarations.sh): correct copy command for macOS

### DIFF
--- a/emitDeclarations.sh
+++ b/emitDeclarations.sh
@@ -2,7 +2,7 @@
 ./node_modules/typescript/bin/tsc -p tsconfig.declarations.json
 os=`uname`
 if [ "$os" = "Darwin" ]; then
-    cp -R types dist
+    cp -R types/ dist
 else
     cp -RT types dist
 fi


### PR DESCRIPTION
The copy-command used for macOS (Darwin) in emitDeclarations.sh was missing a slash at the end, causing the resulting file-structure to be incorrect.

Fixes #1665