### PR TITLE
Fix height calculation.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1996,12 +1996,9 @@ function FlatpickrInstance(
     triggerEvent("onPreCalendarPosition");
     const positionElement = customPositionElement || self._positionElement;
 
-    const calendarHeight = Array.prototype.reduce.call(
-        self.calendarContainer.children,
-        ((acc: number, child: HTMLElement) => acc + child.offsetHeight) as any,
-        0
-      ),
-      calendarWidth = self.calendarContainer.offsetWidth,
+    const calendarBounds = self.calendarContainer.getBoundingClientRect(),
+      calendarHeight = calendarBounds.height,
+      calendarWidth = calendarBounds.width,
       configPos = self.config.position.split(" "),
       configPosVertical = configPos[0],
       configPosHorizontal = configPos.length > 1 ? configPos[1] : null,


### PR DESCRIPTION
If the `calendarContainer` children were styled to be side-by-side instead of one after another, the height calculation was not working correctly.

![image](https://user-images.githubusercontent.com/7904/53766399-bababb00-3ea0-11e9-9d50-b78b11e18a28.png)
