### PR TITLE
Add time_24h config variable to locale files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1088,6 +1088,7 @@ function FlatpickrInstance(
       self.timeContainer.appendChild(secondInput);
     }
 
+    console.log("index.ts:1091", self.config.time_24hr);
     if (!self.config.time_24hr) {
       // add self.amPM if appropriate
       self.amPM = createElement(
@@ -1982,6 +1983,13 @@ function FlatpickrInstance(
     tokenRegex.K = `(${self.l10n.amPM[0]}|${
       self.l10n.amPM[1]
     }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;
+
+    self.config.time_24hr = Object.prototype.hasOwnProperty.call(
+      self.l10n,
+      "time_24hr"
+    )
+      ? self.l10n.time_24hr
+      : self.config.time_24hr;
 
     self.formatDate = createDateFormatter(self);
     self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1088,7 +1088,6 @@ function FlatpickrInstance(
       self.timeContainer.appendChild(secondInput);
     }
 
-    console.log("index.ts:1091", self.config.time_24hr);
     if (!self.config.time_24hr) {
       // add self.amPM if appropriate
       self.amPM = createElement(

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ function FlatpickrInstance(
 ): Instance {
   const self = {
     config: {
+      ...defaultOptions,
       ...flatpickr.defaultConfig,
     } as ParsedOptions,
     l10n: English,
@@ -1868,12 +1869,12 @@ function FlatpickrInstance(
     const timeMode = userConfig.mode === "time";
 
     if (!userConfig.dateFormat && (userConfig.enableTime || timeMode)) {
+      const defaultDateFormat =
+        flatpickr.defaultConfig.dateFormat || defaultOptions.dateFormat;
       formats.dateFormat =
         userConfig.noCalendar || timeMode
           ? "H:i" + (userConfig.enableSeconds ? ":S" : "")
-          : flatpickr.defaultConfig.dateFormat +
-            " H:i" +
-            (userConfig.enableSeconds ? ":S" : "");
+          : defaultDateFormat + " H:i" + (userConfig.enableSeconds ? ":S" : "");
     }
 
     if (
@@ -1881,11 +1882,12 @@ function FlatpickrInstance(
       (userConfig.enableTime || timeMode) &&
       !userConfig.altFormat
     ) {
+      const defaultAltFormat =
+        flatpickr.defaultConfig.altFormat || defaultOptions.altFormat;
       formats.altFormat =
         userConfig.noCalendar || timeMode
           ? "h:i" + (userConfig.enableSeconds ? ":S K" : " K")
-          : flatpickr.defaultConfig.altFormat +
-            ` h:i${userConfig.enableSeconds ? ":S" : ""} K`;
+          : defaultAltFormat + ` h:i${userConfig.enableSeconds ? ":S" : ""} K`;
     }
 
     Object.defineProperty(self.config, "minDate", {
@@ -1983,12 +1985,17 @@ function FlatpickrInstance(
       self.l10n.amPM[1]
     }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;
 
-    self.config.time_24hr = Object.prototype.hasOwnProperty.call(
-      self.l10n,
-      "time_24hr"
-    )
-      ? self.l10n.time_24hr
-      : self.config.time_24hr;
+    const userConfig = {
+      ...instanceConfig,
+      ...JSON.parse(JSON.stringify(element.dataset || {})),
+    } as Options;
+
+    if (
+      userConfig.time_24hr === undefined &&
+      flatpickr.defaultConfig.time_24hr === undefined
+    ) {
+      self.config.time_24hr = self.l10n.time_24hr;
+    }
 
     self.formatDate = createDateFormatter(self);
     self.parseDate = createDateParser({ config: self.config, l10n: self.l10n });
@@ -2728,7 +2735,7 @@ var flatpickr = function(
 } as FlatpickrFn;
 
 /* istanbul ignore next */
-flatpickr.defaultConfig = defaultOptions;
+flatpickr.defaultConfig = {};
 
 flatpickr.l10ns = {
   en: { ...English },

--- a/src/l10n/az.ts
+++ b/src/l10n/az.ts
@@ -62,6 +62,7 @@ export const Azerbaijan: CustomLocale = {
   scrollTitle: "Artırmaq üçün sürüşdürün",
   toggleTitle: "Aç / Bağla",
   amPM: ["GƏ", "GS"],
+  time_24hr: true,
 };
 
 fp.l10ns.az = Azerbaijan;

--- a/src/l10n/be.ts
+++ b/src/l10n/be.ts
@@ -62,6 +62,7 @@ export const Belarusian: CustomLocale = {
   toggleTitle: "Націсніце для пераключэння",
   amPM: ["ДП", "ПП"],
   yearAriaLabel: "Год",
+  time_24hr: true,
 };
 
 fp.l10ns.be = Belarusian;

--- a/src/l10n/bg.ts
+++ b/src/l10n/bg.ts
@@ -53,6 +53,7 @@ export const Bulgarian: CustomLocale = {
       "Декември",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.bg = Bulgarian;

--- a/src/l10n/cat.ts
+++ b/src/l10n/cat.ts
@@ -72,6 +72,7 @@ export const Catalan: CustomLocale = {
   },
 
   firstDayOfWeek: 1,
+  time_24hr: true,
 };
 
 fp.l10ns.cat = Catalan;

--- a/src/l10n/cs.ts
+++ b/src/l10n/cs.ts
@@ -62,6 +62,7 @@ export const Czech: CustomLocale = {
   toggleTitle: "Přepnout dopoledne/odpoledne",
   amPM: ["dop.", "odp."],
   yearAriaLabel: "Rok",
+  time_24hr: true,
 };
 
 fp.l10ns.cs = Czech;

--- a/src/l10n/cy.ts
+++ b/src/l10n/cy.ts
@@ -89,6 +89,7 @@ export const Welsh: CustomLocale = {
     // Inconclusive.
     return "";
   },
+  time_24hr: true,
 };
 
 fp.l10ns.cy = Welsh;

--- a/src/l10n/da.ts
+++ b/src/l10n/da.ts
@@ -61,6 +61,7 @@ export const Danish: CustomLocale = {
   firstDayOfWeek: 1,
   rangeSeparator: " til ",
   weekAbbreviation: "uge",
+  time_24hr: true,
 };
 
 fp.l10ns.da = Danish;

--- a/src/l10n/de.ts
+++ b/src/l10n/de.ts
@@ -59,6 +59,7 @@ export const German: CustomLocale = {
   rangeSeparator: " bis ",
   scrollTitle: "Zum Ändern scrollen",
   toggleTitle: "Zum Umschalten klicken",
+  time_24hr: true,
 };
 
 fp.l10ns.de = German;

--- a/src/l10n/default.ts
+++ b/src/l10n/default.ts
@@ -65,6 +65,7 @@ export const english: Locale = {
   toggleTitle: "Click to toggle",
   amPM: ["AM", "PM"],
   yearAriaLabel: "Year",
+  time_24hr: false,
 };
 
 export default english;

--- a/src/l10n/eo.ts
+++ b/src/l10n/eo.ts
@@ -64,6 +64,7 @@ export const Esperanto: CustomLocale = {
   ordinal: () => {
     return "-a";
   },
+  time_24hr: true,
 };
 
 fp.l10ns.eo = Esperanto;

--- a/src/l10n/es.ts
+++ b/src/l10n/es.ts
@@ -60,6 +60,7 @@ export const Spanish: CustomLocale = {
 
   firstDayOfWeek: 1,
   rangeSeparator: " a ",
+  time_24hr: true,
 };
 
 fp.l10ns.es = Spanish;

--- a/src/l10n/et.ts
+++ b/src/l10n/et.ts
@@ -64,6 +64,7 @@ export const Estonian: CustomLocale = {
   rangeSeparator: " kuni ",
   scrollTitle: "Keri, et suurendada",
   toggleTitle: "Klõpsa, et vahetada",
+  time_24hr: true,
 };
 
 fp.l10ns.et = Estonian;

--- a/src/l10n/fi.ts
+++ b/src/l10n/fi.ts
@@ -59,6 +59,7 @@ export const Finnish: CustomLocale = {
   ordinal: () => {
     return ".";
   },
+  time_24hr: true,
 };
 
 fp.l10ns.fi = Finnish;

--- a/src/l10n/fo.ts
+++ b/src/l10n/fo.ts
@@ -64,6 +64,7 @@ export const Faroese: CustomLocale = {
   scrollTitle: "Rulla fyri at broyta",
   toggleTitle: "Trýst fyri at skifta",
   yearAriaLabel: "Ár",
+  time_24hr: true,
 };
 
 fp.l10ns.fo = Faroese;

--- a/src/l10n/fr.ts
+++ b/src/l10n/fr.ts
@@ -65,6 +65,7 @@ export const French: CustomLocale = {
   weekAbbreviation: "Sem",
   scrollTitle: "Défiler pour augmenter la valeur",
   toggleTitle: "Cliquer pour basculer",
+  time_24hr: true,
 };
 
 fp.l10ns.fr = French;

--- a/src/l10n/he.ts
+++ b/src/l10n/he.ts
@@ -46,6 +46,7 @@ export const Hebrew: CustomLocale = {
     ],
   },
   rangeSeparator: " אל ",
+  time_24hr: true,
 };
 
 fp.l10ns.he = Hebrew;

--- a/src/l10n/hr.ts
+++ b/src/l10n/hr.ts
@@ -55,6 +55,7 @@ export const Croatian: CustomLocale = {
       "Prosinac",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.hr = Croatian;

--- a/src/l10n/hu.ts
+++ b/src/l10n/hu.ts
@@ -64,6 +64,7 @@ export const Hungarian: CustomLocale = {
   scrollTitle: "Görgessen",
   toggleTitle: "Kattintson a váltáshoz",
   rangeSeparator: " - ",
+  time_24hr: true,
 };
 
 fp.l10ns.hu = Hungarian;

--- a/src/l10n/id.ts
+++ b/src/l10n/id.ts
@@ -51,6 +51,7 @@ export const Indonesian: CustomLocale = {
   ordinal: () => {
     return "";
   },
+  time_24hr: true,
 };
 
 fp.l10ns.id = Indonesian;

--- a/src/l10n/is.ts
+++ b/src/l10n/is.ts
@@ -62,6 +62,7 @@ export const Icelandic: CustomLocale = {
   rangeSeparator: " til ",
   weekAbbreviation: "vika",
   yearAriaLabel: "Ár",
+  time_24hr: true,
 };
 
 fp.l10ns.is = Icelandic;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -53,18 +53,13 @@ export const Italian: CustomLocale = {
       "Dicembre",
     ],
   },
-
   firstDayOfWeek: 1,
-
   ordinal: () => "°",
-
   rangeSeparator: " al ",
-
   weekAbbreviation: "Se",
-
   scrollTitle: "Scrolla per aumentare",
-
   toggleTitle: "Clicca per cambiare",
+  time_24hr: true,
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -53,6 +53,7 @@ export const Japanese: CustomLocale = {
       "12月",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.ja = Japanese;

--- a/src/l10n/km.ts
+++ b/src/l10n/km.ts
@@ -61,6 +61,7 @@ export const Khmer: CustomLocale = {
   scrollTitle: "រំកិលដើម្បីបង្កើន",
   toggleTitle: "ចុចដើម្បីផ្លាស់ប្ដូរ",
   yearAriaLabel: "ឆ្នាំ",
+  time_24hr: true,
 };
 
 fp.l10ns.km = Khmer;

--- a/src/l10n/lt.ts
+++ b/src/l10n/lt.ts
@@ -63,6 +63,7 @@ export const Lithuanian: CustomLocale = {
   weekAbbreviation: "Sav",
   scrollTitle: "Keisti laiką pelės rateliu",
   toggleTitle: "Perjungti laiko formatą",
+  time_24hr: true,
 };
 
 fp.l10ns.lt = Lithuanian;

--- a/src/l10n/lv.ts
+++ b/src/l10n/lv.ts
@@ -57,6 +57,7 @@ export const Latvian: CustomLocale = {
   },
 
   rangeSeparator: " līdz ",
+  time_24hr: true,
 };
 
 fp.l10ns.lv = Latvian;

--- a/src/l10n/mk.ts
+++ b/src/l10n/mk.ts
@@ -57,6 +57,7 @@ export const Macedonian: CustomLocale = {
   firstDayOfWeek: 1,
   weekAbbreviation: "Нед.",
   rangeSeparator: " до ",
+  time_24hr: true,
 };
 
 fp.l10ns.mk = Macedonian;

--- a/src/l10n/mn.ts
+++ b/src/l10n/mn.ts
@@ -47,6 +47,7 @@ export const Mongolian: CustomLocale = {
     ],
   },
   rangeSeparator: "-с ",
+  time_24hr: true,
 };
 
 fp.l10ns.mn = Mongolian;

--- a/src/l10n/my.ts
+++ b/src/l10n/my.ts
@@ -59,6 +59,7 @@ export const Burmese: CustomLocale = {
   ordinal: () => {
     return "";
   },
+  time_24hr: true,
 };
 
 fp.l10ns.my = Burmese;

--- a/src/l10n/nl.ts
+++ b/src/l10n/nl.ts
@@ -59,6 +59,7 @@ export const Dutch: CustomLocale = {
   rangeSeparator: " tot ",
   scrollTitle: "Scroll voor volgende / vorige",
   toggleTitle: "Klik om te wisselen",
+  time_24hr: true,
 
   ordinal: nth => {
     if (nth === 1 || nth === 8 || nth >= 20) return "ste";

--- a/src/l10n/no.ts
+++ b/src/l10n/no.ts
@@ -59,6 +59,7 @@ export const Norwegian: CustomLocale = {
   weekAbbreviation: "Uke",
   scrollTitle: "Scroll for å endre",
   toggleTitle: "Klikk for å veksle",
+  time_24hr: true,
 
   ordinal: () => {
     return ".";

--- a/src/l10n/pa.ts
+++ b/src/l10n/pa.ts
@@ -53,6 +53,7 @@ export const Punjabi: CustomLocale = {
       "ਦਸੰਬਰ",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.pa = Punjabi;

--- a/src/l10n/pl.ts
+++ b/src/l10n/pl.ts
@@ -57,8 +57,8 @@ export const Polish: CustomLocale = {
   weekAbbreviation: "tydz.",
   scrollTitle: "Przwiń aby zwiększyć",
   toggleTitle: "Kliknij aby przełączyć",
-
   firstDayOfWeek: 1,
+  time_24hr: true,
 
   ordinal: () => {
     return ".";

--- a/src/l10n/pt.ts
+++ b/src/l10n/pt.ts
@@ -55,6 +55,7 @@ export const Portuguese: CustomLocale = {
   },
 
   rangeSeparator: " até ",
+  time_24hr: true,
 };
 
 fp.l10ns.pt = Portuguese;

--- a/src/l10n/ro.ts
+++ b/src/l10n/ro.ts
@@ -11,7 +11,7 @@ const fp =
 
 export const Romanian: CustomLocale = {
   weekdays: {
-    shorthand: ["Dum", "Lun", "Mar", "Mie", "Joi", "Vin", "Sam"],
+    shorthand: ["Dum", "Lun", "Mar", "Mie", "Joi", "Vin", "Sâm"],
     longhand: [
       "Duminică",
       "Luni",
@@ -55,6 +55,7 @@ export const Romanian: CustomLocale = {
   },
 
   firstDayOfWeek: 1,
+  time_24hr: true,
 
   ordinal: () => {
     return "";

--- a/src/l10n/ru.ts
+++ b/src/l10n/ru.ts
@@ -62,6 +62,7 @@ export const Russian: CustomLocale = {
   toggleTitle: "Нажмите для переключения",
   amPM: ["ДП", "ПП"],
   yearAriaLabel: "Год",
+  time_24hr: true,
 };
 
 fp.l10ns.ru = Russian;

--- a/src/l10n/si.ts
+++ b/src/l10n/si.ts
@@ -53,6 +53,7 @@ export const Sinhala: CustomLocale = {
       "දෙසැම්බර්",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.si = Sinhala;

--- a/src/l10n/sk.ts
+++ b/src/l10n/sk.ts
@@ -56,6 +56,7 @@ export const Slovak: CustomLocale = {
 
   firstDayOfWeek: 1,
   rangeSeparator: " do ",
+  time_24hr: true,
   ordinal: function() {
     return ".";
   },

--- a/src/l10n/sl.ts
+++ b/src/l10n/sl.ts
@@ -56,6 +56,7 @@ export const Slovenian: CustomLocale = {
 
   firstDayOfWeek: 1,
   rangeSeparator: " do ",
+  time_24hr: true,
   ordinal: function() {
     return ".";
   },

--- a/src/l10n/sq.ts
+++ b/src/l10n/sq.ts
@@ -53,6 +53,7 @@ export const Albanian: CustomLocale = {
       "Dhjetor",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.sq = Albanian;

--- a/src/l10n/sr.ts
+++ b/src/l10n/sr.ts
@@ -57,6 +57,7 @@ export const Serbian: CustomLocale = {
   firstDayOfWeek: 1,
   weekAbbreviation: "Ned.",
   rangeSeparator: " do ",
+  time_24hr: true,
 };
 
 fp.l10ns.sr = Serbian;

--- a/src/l10n/sv.ts
+++ b/src/l10n/sv.ts
@@ -56,6 +56,7 @@ export const Swedish: CustomLocale = {
       "December",
     ],
   },
+  time_24hr: true,
 
   ordinal: () => {
     return ".";

--- a/src/l10n/th.ts
+++ b/src/l10n/th.ts
@@ -58,6 +58,7 @@ export const Thai: CustomLocale = {
   rangeSeparator: " ถึง ",
   scrollTitle: "เลื่อนเพื่อเพิ่มหรือลด",
   toggleTitle: "คลิกเพื่อเปลี่ยน",
+  time_24hr: true,
 
   ordinal: () => {
     return "";

--- a/src/l10n/tr.ts
+++ b/src/l10n/tr.ts
@@ -62,6 +62,7 @@ export const Turkish: CustomLocale = {
   scrollTitle: "Artırmak için kaydırın",
   toggleTitle: "Aç/Kapa",
   amPM: ["ÖÖ", "ÖS"],
+  time_24hr: true,
 };
 
 fp.l10ns.tr = Turkish;

--- a/src/l10n/uk.ts
+++ b/src/l10n/uk.ts
@@ -55,6 +55,7 @@ export const Ukrainian: CustomLocale = {
       "Грудень",
     ],
   },
+  time_24hr: true,
 };
 
 fp.l10ns.uk = Ukrainian;

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -150,7 +150,7 @@ export interface FlatpickrFn {
   (selector: Node, config?: Options): Instance;
   (selector: ArrayLike<Node>, config?: Options): Instance[];
   (selector: string, config?: Options): Instance | Instance[];
-  defaultConfig: ParsedOptions;
+  defaultConfig: Partial<ParsedOptions>;
   l10ns: { [k in LocaleKey]?: CustomLocale } & { default: Locale };
   localize: (l10n: CustomLocale) => void;
   setDefaults: (config: Options) => void;

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -55,6 +55,7 @@ export type Locale = {
   toggleTitle: string;
   amPM: [string, string];
   yearAriaLabel: string;
+  time_24hr: boolean;
 };
 
 export type CustomLocale = {
@@ -67,6 +68,7 @@ export type CustomLocale = {
   scrollTitle?: Locale["scrollTitle"];
   yearAriaLabel?: string;
   amPM?: Locale["amPM"];
+  time_24hr?: Locale["time_24hr"];
   weekdays: {
     shorthand: [string, string, string, string, string, string, string];
     longhand: [string, string, string, string, string, string, string];


### PR DESCRIPTION
Adds a time_24h boolean parameter to the locale files to allow the pickr to default to the 24h picker based on the country.

I took the list of languages that should allow 24h formats from `toLocaleDateString()`