### PR TITLE
Bugfix for #1423

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2333,7 +2333,7 @@ function FlatpickrInstance(
         ? null
         : self.input.value);
 
-    if (preloadedDate) setSelectedDate(preloadedDate, self.config.dateFormat);
+    if (preloadedDate) setSelectedDate(preloadedDate, self.config.altInput ? self.config.altFormat : self.config.dateFormat);
 
     self._initialDate =
       self.selectedDates.length > 0


### PR DESCRIPTION
While setting up dates, default `dateFormat` is considered instead of `altFormat` when `altInput` is true. Added a condition to get `altFormat` if `altInput` is true.