### PR TITLE
Added loadedPlugins attribute on fp instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ function FlatpickrInstance(
 
   self._handlers = [];
   self.pluginElements = [];
+  self.loadedPlugins = [];
   self._bind = bind;
   self._setHoursFromDate = setHoursFromDate;
   self._positionCalendar = positionCalendar;

--- a/src/plugins/confirmDate/confirmDate.ts
+++ b/src/plugins/confirmDate/confirmDate.ts
@@ -52,10 +52,6 @@ function confirmDatePlugin(pluginConfig: Config): Plugin {
       ...(!config.showAlways
         ? {
             onChange: function(_: Date[], dateStr: string) {
-              fp.config.plugins.forEach(test => {
-                console.log("confirmDate.ts:53", test);
-              });
-
               const showCondition =
                 fp.config.enableTime || fp.config.mode === "multiple";
 

--- a/src/plugins/confirmDate/confirmDate.ts
+++ b/src/plugins/confirmDate/confirmDate.ts
@@ -46,10 +46,16 @@ function confirmDatePlugin(pluginConfig: Config): Plugin {
 
         confirmContainer.addEventListener("click", fp.close);
         fp.calendarContainer.appendChild(confirmContainer);
+
+        fp.loadedPlugins.push("confirmDate");
       },
       ...(!config.showAlways
         ? {
             onChange: function(_: Date[], dateStr: string) {
+              fp.config.plugins.forEach(test => {
+                console.log("confirmDate.ts:53", test);
+              });
+
               const showCondition =
                 fp.config.enableTime || fp.config.mode === "multiple";
 

--- a/src/plugins/labelPlugin/labelPlugin.ts
+++ b/src/plugins/labelPlugin/labelPlugin.ts
@@ -17,6 +17,8 @@ function labelPlugin(): Plugin {
           fp.input.removeAttribute("id");
           fp.altInput.id = id;
         }
+
+        fp.loadedPlugins.push("labelPlugin");
       },
     };
   };

--- a/src/plugins/minMaxTimePlugin.ts
+++ b/src/plugins/minMaxTimePlugin.ts
@@ -52,6 +52,7 @@ function minMaxTimePlugin(config: Config = {}): Plugin {
           maxTime:
             this.config.maxTime && state.formatDate(this.config.maxTime, "H:i"),
         };
+        fp.loadedPlugins.push("minMaxTime");
       },
 
       onChange(this: Instance) {

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -186,6 +186,9 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         addListeners,
         addMonths,
         setCurrentlySelected,
+        () => {
+          fp.loadedPlugins.push("monthSelect");
+        },
       ],
       onDestroy: destroyPluginInstance,
     };

--- a/src/plugins/rangePlugin.ts
+++ b/src/plugins/rangePlugin.ts
@@ -117,6 +117,7 @@ function rangePlugin(config: Config = {}): Plugin {
 
         fp.setDate(fp.selectedDates, false);
         plugin.onValueUpdate(fp.selectedDates);
+        fp.loadedPlugins.push("range");
       },
 
       onPreCalendarPosition() {

--- a/src/plugins/scrollPlugin.ts
+++ b/src/plugins/scrollPlugin.ts
@@ -37,6 +37,8 @@ function scrollPlugin(): Plugin {
         fp.monthElements.forEach(monthElem =>
           monthElem.addEventListener("wheel", monthScroller)
         );
+
+        fp.loadedPlugins.push("scroll");
       },
       onDestroy() {
         if (fp.timeContainer) {

--- a/src/plugins/weekSelect/weekSelect.ts
+++ b/src/plugins/weekSelect/weekSelect.ts
@@ -89,7 +89,13 @@ function weekSelectPlugin(): Plugin<PlusWeeks> {
           ? fp.config.altFormat
           : "\\W\\e\\e\\k #W, Y";
       },
-      onReady: [onReady, highlightWeek],
+      onReady: [
+        onReady,
+        highlightWeek,
+        () => {
+          fp.loadedPlugins.push("weekSelect");
+        },
+      ],
       onDestroy,
     };
   };

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -69,6 +69,7 @@ export type Instance = Elements &
 
     // State
     config: ParsedOptions;
+    loadedPlugins: string[];
     l10n: Locale;
 
     currentYear: number;


### PR DESCRIPTION
I was looking for a clean way to check that the monthSelect plugin has been loaded inside the confirmDate plugin (to enable the confirm button if the monthSelect is loaded) and there wasn't any. I added an attribute called loadedPlugins on the fp instance in which each plugin pushes its own name.

Same problem was referenced in #1217 