### PR TITLE
Monthselect plugin dark theme parameter now works standalone

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -61,7 +61,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
 
       self.monthsContainer.tabIndex = -1;
 
-      self.monthsContainer.classList.add(
+      fp.calendarContainer.classList.add(
         `flatpickr-monthSelect-theme-${config.theme}`
       );
 

--- a/src/plugins/monthSelect/style.css
+++ b/src/plugins/monthSelect/style.css
@@ -24,6 +24,20 @@
   width: 33%;
 }
 
+.flatpickr-monthSelect-theme-dark {
+  background: #3f4458;
+}
+
+.flatpickr-monthSelect-theme-dark .flatpickr-current-month input.cur-year {
+  color: #fff;
+}
+
+.flatpickr-monthSelect-theme-dark .flatpickr-months .flatpickr-prev-month,
+.flatpickr-monthSelect-theme-dark .flatpickr-months .flatpickr-next-month {
+  color: #fff;
+  fill: #fff;
+}
+
 .flatpickr-monthSelect-theme-dark .flatpickr-monthSelect-month {
   color: rgba(255, 255, 255, 0.95);
 }


### PR DESCRIPTION
Realized that the dark theme parameter for the month select plugin required the dark theme in the main picker to look ok. I made it work without it also