### PR TITLE
Modified destroy method for bug #1641

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1278,7 +1278,6 @@ function FlatpickrInstance(
       self.input.type = (self.input as any)._type;
       self.input.classList.remove("flatpickr-input");
       self.input.removeAttribute("readonly");
-      self.input.value = "";
     }
 
     ([


### PR DESCRIPTION
 There is no need to empty input element value on destroying flatpickr instance