### PR TITLE
Build system improvements

### DIFF
--- a/config/rollup.ts
+++ b/config/rollup.ts
@@ -15,6 +15,7 @@ export const getConfig = (opts?: { dev: boolean }): RollupOptions => ({
     format: "umd",
     exports: "default",
     banner: `/* flatpickr v${pkg.version}, @license MIT */`,
+    sourcemap: (opts != undefined ? opts.dev : false),
   },
   experimentalOptimizeChunks: true,
   onwarn(warning) {
@@ -38,7 +39,7 @@ export const getConfig = (opts?: { dev: boolean }): RollupOptions => ({
           serve({
             open: true,
             contentBase: "",
-            host: "0.0.0.0",
+            host: "127.0.0.1",
             port: 8000,
           }),
           livereload(),

--- a/emitDeclarations.sh
+++ b/emitDeclarations.sh
@@ -10,4 +10,4 @@ cp src/typings.d.ts dist/typings.d.ts
 rm -rf types
 
 # https://github.com/Microsoft/TypeScript/issues/26439
-fd '.d.ts' dist/l10n --exec sed -i -e 's/"types/"..\/types/g' {}
+find dist/l10n -name '*d.ts' -exec sed -i -e 's/"types/"..\/types/g' {} \;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight, powerful javascript datetime picker",
   "scripts": {
     "build": "run-s build:pre build:build build:post",
-    "build:pre": "rm -rf dist && mkdir -p dist/themes",
+    "build:pre": "sh -c 'rm -rf dist; mkdir -p dist/themes'",
     "build:build": "ts-node --transpile-only build.ts",
     "build:post": "sh ./emitDeclarations.sh",
     "fmt": "prettier --ignore-path .gitignore --trailing-comma es5 --write '**/*.ts'",


### PR DESCRIPTION
I am looking at doing some development and bug fixing.
These changes help me and hopefully others debug and build in vscode which is very popular and cross platform.
The changes are not code editor specific so I think they are a good addition.

1.  Emitting a sourcemap lets me attach a chrome debugger and set breakpoints in typescript using vscode..
2.  Making the build scripts more cross platform means build system is more accessible.

I changed fd for find as fd is not always available by default.

Tested on windows 7  with git bash and mac.