### PR TITLE
Add millisecond formatting/parsing

### DIFF
--- a/src/plugins/millisecondFormatConfig/millisecondFormatConfig.ts
+++ b/src/plugins/millisecondFormatConfig/millisecondFormatConfig.ts
@@ -1,0 +1,38 @@
+import { FlatpickrFn } from "../../types/instance";
+
+function millisecondFormatConfig(flatpickrFn: FlatpickrFn): void {
+
+  const fpGlobalConfig = flatpickrFn.getGlobalConfig();
+
+  // WARNING: As configs are only ever shallow copied, changes to existing config
+  // child objects would affect:
+  //          the global config,
+  //          the config in new flatpickr instances,
+  //          AND alarmingly existing flatpickr instances.
+  // So don't do this:
+  //   fpGlobalConfig.formatFns!["v"] = (date: Date) => date.getMilliseconds();
+  // use flatpickrFn.setDefaults instead.
+
+  flatpickrFn.setDefaults({
+    formatFns: {
+      ...fpGlobalConfig.formatFns,
+      // milliseconds 000-999
+      v: (date: Date) => ("00" + date.getMilliseconds()).slice(-3),
+    },
+    parseTokenRegexs: {
+      ...fpGlobalConfig.parseTokenRegexs,
+      v: "(\\d\\d|\\d)",
+    },
+    parseTokenFns: {
+      ...fpGlobalConfig.parseTokenFns,
+      v: (
+        dateObj: Date,
+        milliseconds: string
+      ) => {
+        dateObj.setMilliseconds(parseFloat(milliseconds));
+      }
+    }
+  });
+}
+
+export default millisecondFormatConfig;

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -1,8 +1,6 @@
 import { DateOption, Options, ParsedOptions } from "./options";
 import { Locale, CustomLocale, key as LocaleKey } from "./locale";
 
-import { RevFormat, Formats, TokenRegex } from "../utils/formatting";
-
 export interface Elements {
   element: HTMLElement;
   input: HTMLInputElement;
@@ -50,110 +48,110 @@ export interface Elements {
   pluginElements: Array<Node>;
 }
 
-export interface Formatting {
-  revFormat: RevFormat;
-  formats: Formats;
-  tokenRegex: TokenRegex;
-}
+export type Instance = Elements & {
+  // Dates
+  minRangeDate?: Date;
+  maxRangeDate?: Date;
+  now: Date;
+  latestSelectedDateObj?: Date;
+  _selectedDateObj?: Date;
+  selectedDates: Date[];
+  _initialDate: Date;
 
-export type Instance = Elements &
-  Formatting & {
-    // Dates
-    minRangeDate?: Date;
-    maxRangeDate?: Date;
-    now: Date;
-    latestSelectedDateObj?: Date;
-    _selectedDateObj?: Date;
-    selectedDates: Date[];
-    _initialDate: Date;
+  // State
+  config: ParsedOptions;
+  loadedPlugins: string[];
+  l10n: Locale;
 
-    // State
-    config: ParsedOptions;
-    loadedPlugins: string[];
-    l10n: Locale;
+  currentYear: number;
+  currentMonth: number;
 
-    currentYear: number;
-    currentMonth: number;
+  isOpen: boolean;
+  isMobile: boolean;
 
-    isOpen: boolean;
-    isMobile: boolean;
+  minDateHasTime: boolean;
+  maxDateHasTime: boolean;
 
-    minDateHasTime: boolean;
-    maxDateHasTime: boolean;
+  showTimeInput: boolean;
+  _showTimeInput: boolean;
 
-    showTimeInput: boolean;
-    _showTimeInput: boolean;
+  // Methods
+  changeMonth: (
+    value: number,
+    is_offset?: boolean,
+    from_keyboard?: boolean
+  ) => void;
+  changeYear: (year: number) => void;
+  clear: (emitChangeEvent?: boolean, toInitial?: boolean) => void;
+  close: () => void;
+  destroy: () => void;
+  isEnabled: (date: DateOption, timeless?: boolean) => boolean;
+  jumpToDate: (date?: DateOption) => void;
+  open: (e?: FocusEvent | MouseEvent, positionElement?: HTMLElement) => void;
+  redraw: () => void;
+  set: (
+    option: keyof Options | { [k in keyof Options]?: Options[k] },
+    value?: any
+  ) => void;
+  setDate: (
+    date: DateOption | DateOption[],
+    triggerChange?: boolean,
+    format?: string
+  ) => void;
+  toggle: () => void;
 
-    // Methods
-    changeMonth: (
-      value: number,
-      is_offset?: boolean,
-      from_keyboard?: boolean
-    ) => void;
-    changeYear: (year: number) => void;
-    clear: (emitChangeEvent?: boolean, toInitial?: boolean) => void;
-    close: () => void;
-    destroy: () => void;
-    isEnabled: (date: DateOption, timeless?: boolean) => boolean;
-    jumpToDate: (date?: DateOption) => void;
-    open: (e?: FocusEvent | MouseEvent, positionElement?: HTMLElement) => void;
-    redraw: () => void;
-    set: (
-      option: keyof Options | { [k in keyof Options]?: Options[k] },
-      value?: any
-    ) => void;
-    setDate: (
-      date: DateOption | DateOption[],
-      triggerChange?: boolean,
-      format?: string
-    ) => void;
-    toggle: () => void;
+  pad: (num: string | number) => string;
+  parseDate: (
+    date: Date | string | number,
+    givenFormat?: string,
+    timeless?: boolean
+  ) => Date | undefined;
+  formatDate: (dateObj: Date, frmt: string) => string;
 
-    pad: (num: string | number) => string;
-    parseDate: (
-      date: Date | string | number,
-      givenFormat?: string,
-      timeless?: boolean
-    ) => Date | undefined;
-    formatDate: (dateObj: Date, frmt: string) => string;
+  // Internals
 
-    // Internals
+  _handlers: {
+    event: string;
+    element: Element;
+    handler: (e?: Event) => void;
+    options?: { capture?: boolean };
+  }[];
 
-    _handlers: {
-      event: string;
-      element: Element;
-      handler: (e?: Event) => void;
-      options?: { capture?: boolean };
-    }[];
+  _bind: <E extends Element>(
+    element: E | E[],
+    event: string | string[],
+    handler: (e?: any) => void
+  ) => void;
+  _createElement: <E extends HTMLElement>(
+    tag: keyof HTMLElementTagNameMap,
+    className: string,
+    content?: string
+  ) => E;
+  _setHoursFromDate: (date: Date) => void;
+  _debouncedChange: () => void;
+  __hideNextMonthArrow: boolean;
+  __hidePrevMonthArrow: boolean;
+  _positionCalendar: (customPositionElement?: HTMLElement) => void;
 
-    _bind: <E extends Element>(
-      element: E | E[],
-      event: string | string[],
-      handler: (e?: any) => void
-    ) => void;
-    _createElement: <E extends HTMLElement>(
-      tag: keyof HTMLElementTagNameMap,
-      className: string,
-      content?: string
-    ) => E;
-    _setHoursFromDate: (date: Date) => void;
-    _debouncedChange: () => void;
-    __hideNextMonthArrow: boolean;
-    __hidePrevMonthArrow: boolean;
-    _positionCalendar: (customPositionElement?: HTMLElement) => void;
-
-    utils: {
-      getDaysInMonth: (month?: number, year?: number) => number;
-    };
+  utils: {
+    getDaysInMonth: (month?: number, year?: number) => number;
   };
+};
 
 export interface FlatpickrFn {
   (selector: Node, config?: Options): Instance;
   (selector: ArrayLike<Node>, config?: Options): Instance[];
   (selector: string, config?: Options): Instance | Instance[];
   defaultConfig: Partial<ParsedOptions>;
+
+  /** Get current global config i.e. the union of application defaults & global default config.
+   * Used by static parseDate, formatDate as well as new FlatPickr instances */
+  getGlobalConfig: () => ParsedOptions;
   l10ns: { [k in LocaleKey]?: CustomLocale } & { default: Locale };
   localize: (l10n: CustomLocale) => void;
+
+  /** Set global default config. Combined with application defaults to be
+   * used by static parseDate, formatDate as well as new FlatPickr instances */
   setDefaults: (config: Options) => void;
   parseDate: (
     date: DateOption,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,3 +1,7 @@
+import {
+  FormatFns, ParseTokenFns, ParseTokenRegexs,
+  defaultFormatFns, defaultParseTokenFns, defaultParseTokenRegexs
+} from "./../utils/formatting";
 import { Instance } from "./instance";
 import { CustomLocale, key as LocaleKey, Locale } from "./locale";
 
@@ -128,6 +132,9 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   /* Allows using a custom date formatting function instead of the built-in. Generally unnecessary.  */
   formatDate: (date: Date, format: string, locale: Locale) => string;
 
+  /* Functions used to format a string from a date. Preset to support documented tokens */
+  formatFns: FormatFns;
+
   /* If "weekNumbers" are enabled, this is the function that outputs the week number for a given dates, optionally along with other text  */
   getWeek: (date: Date) => string | number;
 
@@ -211,6 +218,12 @@ Use it along with "enableTime" to create a time picker. */
   /* A custom datestring parser */
   parseDate: (date: string, format: string) => Date;
 
+  /* Functions used to parse a string tokens to a date. Preset to support documented tokens */
+  parseTokenFns: ParseTokenFns;
+
+  /* Regexs used to identify tokens of an input string. Preset to support documented tokens */
+  parseTokenRegexs: ParseTokenRegexs;
+
   /* Plugins. See https://chmln.github.io/flatpickr/plugins/ */
   plugins: Plugin[];
 
@@ -275,6 +288,7 @@ export interface ParsedOptions {
   enableTime: boolean;
   errorHandler: (err: Error) => void;
   formatDate?: Options["formatDate"];
+  formatFns: FormatFns;
   getWeek: (date: Date) => string | number;
   hourIncrement: number;
   ignoredFocusElements: HTMLElement[];
@@ -302,6 +316,8 @@ export interface ParsedOptions {
   onYearChange: Hook[];
   onPreCalendarPosition: Hook[];
   parseDate?: BaseOptions["parseDate"];
+  parseTokenFns: ParseTokenFns;
+  parseTokenRegexs: ParseTokenRegexs;
   plugins: Plugin[];
   position: BaseOptions["position"];
   positionElement?: HTMLElement;
@@ -339,6 +355,7 @@ export const defaults: ParsedOptions = {
   enableTime: false,
   errorHandler: (err: Error) =>
     typeof console !== "undefined" && console.warn(err),
+  formatFns: defaultFormatFns,
   getWeek: (givenDate: Date) => {
     const date = new Date(givenDate.getTime());
     date.setHours(0, 0, 0, 0);
@@ -382,6 +399,8 @@ export const defaults: ParsedOptions = {
   onValueUpdate: [],
   onYearChange: [],
   onPreCalendarPosition: [],
+  parseTokenFns: defaultParseTokenFns,
+  parseTokenRegexs: defaultParseTokenRegexs,
   plugins: [],
   position: "auto",
   positionElement: undefined,

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -2,31 +2,6 @@ import { int, pad } from "../utils";
 import { Locale } from "../types/locale";
 import { ParsedOptions } from "../types/options";
 
-export type token =
-  | "D"
-  | "F"
-  | "G"
-  | "H"
-  | "J"
-  | "K"
-  | "M"
-  | "S"
-  | "U"
-  | "W"
-  | "Y"
-  | "Z"
-  | "d"
-  | "h"
-  | "i"
-  | "j"
-  | "l"
-  | "m"
-  | "n"
-  | "s"
-  | "u"
-  | "w"
-  | "y";
-
 const do_nothing = (): undefined => undefined;
 
 export const monthToStr = (
@@ -35,13 +10,13 @@ export const monthToStr = (
   locale: Locale
 ) => locale.months[shorthand ? "shorthand" : "longhand"][monthNumber];
 
-export type RevFormatFn = (
+export type ParseTokenFn = (
   date: Date,
   data: string,
   locale: Locale
 ) => Date | void | undefined;
-export type RevFormat = Record<string, RevFormatFn>;
-export const revFormat: RevFormat = {
+export type ParseTokenFns = Record<string, ParseTokenFn>;
+export const defaultParseTokenFns: ParseTokenFns = {
   D: do_nothing,
   F: function(dateObj: Date, monthName: string, locale: Locale) {
     dateObj.setMonth(locale.months.longhand.indexOf(monthName));
@@ -116,8 +91,8 @@ export const revFormat: RevFormat = {
   },
 };
 
-export type TokenRegex = { [k in token]: string };
-export const tokenRegex: TokenRegex = {
+export type ParseTokenRegexs = Record<string, string>;
+export const defaultParseTokenRegexs: ParseTokenRegexs = {
   D: "(\\w+)",
   F: "(\\w+)",
   G: "(\\d\\d|\\d)",
@@ -143,25 +118,25 @@ export const tokenRegex: TokenRegex = {
   y: "(\\d{2})",
 };
 
-export type Formats = Record<
-  token,
+export type FormatFns = Record<
+  string,
   (date: Date, locale: Locale, options: ParsedOptions) => string | number
 >;
-export const formats: Formats = {
+export const defaultFormatFns: FormatFns = {
   // get the date in UTC
   Z: (date: Date) => date.toISOString(),
 
   // weekday name, short, e.g. Thu
   D: function(date: Date, locale: Locale, options: ParsedOptions) {
     return locale.weekdays.shorthand[
-      formats.w(date, locale, options) as number
+      defaultFormatFns.w(date, locale, options) as number
     ];
   },
 
   // full month name e.g. January
   F: function(date: Date, locale: Locale, options: ParsedOptions) {
     return monthToStr(
-      (formats.n(date, locale, options) as number) - 1,
+      (defaultFormatFns.n(date, locale, options) as number) - 1,
       false,
       locale
     );
@@ -169,7 +144,7 @@ export const formats: Formats = {
 
   // padded hour 1-12
   G: function(date: Date, locale: Locale, options: ParsedOptions) {
-    return pad(formats.h(date, locale, options));
+    return pad(defaultFormatFns.h(date, locale, options));
   },
 
   // hours with leading zero e.g. 03


### PR DESCRIPTION
formatting preset vars to defaultXxx
Add format vars to options
Remove never set Instance.Formatting vars

Change formatDate, parseDate to use config format vars
Remove redundant type token (any token can be added)

flatpickr.getGlobalConfig()
Update static formatDate, parseDate to use global config
 (not just defaults)

Add millisecondFormatConfig