### PR TITLE
Allow rebuild on powershell and cmd.

### DIFF
--- a/emitDeclarations.sh
+++ b/emitDeclarations.sh
@@ -8,6 +8,3 @@ else
 fi
 cp src/typings.d.ts dist/typings.d.ts
 rm -rf types
-
-# https://github.com/Microsoft/TypeScript/issues/26439
-find dist/l10n -name '*d.ts' -exec sed -i -e 's/"types/"..\/types/g' {} \;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight, powerful javascript datetime picker",
   "scripts": {
     "build": "run-s build:pre build:build build:post",
-    "build:pre": "sh -c 'rm -rf dist; mkdir -p dist/themes'",
+    "build:pre": "sh -c 'rm -rf dist'",
     "build:build": "ts-node --transpile-only build.ts",
     "build:post": "sh ./emitDeclarations.sh",
     "fmt": "prettier --ignore-path .gitignore --trailing-comma es5 --write '**/*.ts'",


### PR DESCRIPTION
Remove unnecessary mkdir. this is already done in build.ts

https://github.com/flatpickr/flatpickr/blob/0e1014b156ca8db18501ed7f33608ab192efa9d5/build.ts#L253

Remove unnecessary find command as relative paths are already correct after compile.

The upshot of this is `npm run build` now works on cmd and powershell on windows which are common shells.

