### PR TITLE
Source maps for --dev

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -16,7 +16,7 @@ import rollupConfig, { getConfig } from "./config/rollup";
 import * as pkg from "./package.json";
 const version = `/* flatpickr v${pkg.version},, @license MIT */`;
 
-let DEV_MODE = false;
+let DEV_MODE = process.argv.indexOf("--dev") > -1;
 
 const paths = {
   themes: "./src/style/themes/*.styl",
@@ -212,8 +212,6 @@ function watch(path: string, cb: (path: string) => void) {
 }
 
 async function start() {
-  DEV_MODE = process.argv.indexOf("--dev") > -1;
-
   if (DEV_MODE) {
     rollupConfig.output!.sourcemap = true;
     const indexExists = await fs.pathExists( './index.html');

--- a/config/rollup.ts
+++ b/config/rollup.ts
@@ -15,7 +15,7 @@ export const getConfig = (opts?: { dev: boolean }): RollupOptions => ({
     format: "umd",
     exports: "default",
     banner: `/* flatpickr v${pkg.version}, @license MIT */`,
-    sourcemap: (opts != undefined ? opts.dev : false),
+    ...(opts && opts.dev) ? {sourcemap: true} : {}
   },
   experimentalOptimizeChunks: true,
   onwarn(warning) {


### PR DESCRIPTION
Finally I managed to sourcemap all the things.
This means when we do `npm start` we can set breakpoints in typescript code.
This includes locales and plugins so debugging will be much easier.
I will add the launch config for vscode in another PR but it makes debugging so easy for new devs.

Hopefully with this and some docs for editors we can get more people fixing bugs.

Took me quite a few hours to workout what was happening with rollupConfig but I'm pretty confident its all ok.

For release build just

`npm run build`

which will delete dist and recompile with out sourcemaps as before.