### PR TITLE
Fix test - fails strict null checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ignore-path .gitignore \"**/*.ts\"",
     "start": "npm run build:build -- --dev",
     "test": "run-s test:typecheck test:unit",
-    "test:typecheck": "tsc -p src --noEmit",
+    "test:typecheck": "tsc --noEmit",
     "test:unit": "jest --config config/jest.json",
     "coveralls": "npm run test:unit -- --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1384,6 +1384,9 @@ describe("flatpickr", () => {
 
       if (!fp.hourElement || !fp.minuteElement || !fp.amPM) return;
 
+      fp.minuteElement.focus();
+      expect(document.activeElement).toStrictEqual(fp.minuteElement);
+
       simulate(
         "keydown",
         fp.minuteElement,

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1378,10 +1378,15 @@ describe("flatpickr", () => {
       createInstance({ mode: "time" });
       fp.open();
 
-      fp.minuteElement.focus();
+      expect(fp.hourElement).toBeDefined();
+      expect(fp.minuteElement).toBeDefined();
+      expect(fp.amPM).toBeDefined();
+
+      if (!fp.hourElement || !fp.minuteElement || !fp.amPM) return;
+
       simulate(
         "keydown",
-        document.activeElement,
+        fp.minuteElement,
         {
           keyCode: 9, // Tab
         },
@@ -1391,7 +1396,7 @@ describe("flatpickr", () => {
 
       simulate(
         "keydown",
-        document.activeElement,
+        fp.amPM,
         {
           keyCode: 9, // Tab
           shiftKey: true,
@@ -1400,10 +1405,9 @@ describe("flatpickr", () => {
       );
       expect(document.activeElement).toStrictEqual(fp.minuteElement);
 
-      fp.amPM.focus();
       simulate(
         "keydown",
-        fp.amPM!,
+        fp.amPM,
         {
           keyCode: 9, // Tab
         },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,7 +15,4 @@
     ],
     "baseUrl": "./"
   },
-  "exclude": [
-    "./__tests__"
-  ]
 }


### PR DESCRIPTION
Was failing strict null checking seems to get past roll-up
EDIT see below for commit that solves type checking and will prevent this in the future
Setting focus not required for test.