### PR TITLE
Support ecma 2018 parsing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports =  {
       'plugin:prettier/recommended',  // Prettier rules for eslint
     ],
     parserOptions:  {
-      ecmaVersion:  5,  // Allows for the parsing of modern ECMAScript features
+      ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features
       sourceType:  'module',  // Allows for the use of imports
     },
     rules: { // TODO: The following rules are turned off but need to be addressed.


### PR DESCRIPTION
Since this repo uses some modern ecma language features 
```
"lib": [
      "es2015",
      "dom",
      "es2017.object",
      "esnext.asynciterable"
    ],
```
Note this is only for parsing and linting and does not  upgrade language features that are not already present.
Babel deals with the browser compatibility anyway.