### PR TITLE
Fix @typescript-eslint/camelcase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,6 @@ module.exports =  {
       '@typescript-eslint/no-unused-vars': 'none',
       '@typescript-eslint/no-non-null-assertion': 'none',
       '@typescript-eslint/no-object-literal-type-assertion': 'none',
-      '@typescript-eslint/camelcase': 'none',
+      '@typescript-eslint/camelcase': ['error', { allow: ['time_24hr', 'zh_tw'] }],
     },
   };

--- a/build.ts
+++ b/build.ts
@@ -6,7 +6,7 @@ import glob from "glob";
 import terser from "terser";
 import chokidar from "chokidar";
 import stylus from "stylus";
-import stylus_autoprefixer from "autoprefixer-stylus";
+import stylusAutoprefixer from "autoprefixer-stylus";
 
 import * as rollup from "rollup";
 
@@ -83,12 +83,12 @@ async function buildScripts() {
 }
 
 function buildExtras(folder: "plugins" | "l10n") {
-  return async function(changed_path?: string) {
-    const [src_paths, css_paths] = await Promise.all(
-      changed_path !== undefined
-        ? changed_path.endsWith(".ts")
-          ? [[changed_path], []]
-          : [[], [changed_path]]
+  return async function(changedPath?: string) {
+    const [srcPaths, cssPaths] = await Promise.all(
+      changedPath !== undefined
+        ? changedPath.endsWith(".ts")
+          ? [[changedPath], []]
+          : [[], [changedPath]]
         : [
             resolveGlob(`./src/${folder}/**/*.ts`),
             resolveGlob(`./src/${folder}/**/*.css`),
@@ -97,7 +97,7 @@ function buildExtras(folder: "plugins" | "l10n") {
 
     try {
       await Promise.all([
-        ...src_paths
+        ...srcPaths
           .filter(p => !p.includes(".spec.ts"))
           .map(async sourcePath => {
             const bundle = await rollup.rollup({
@@ -123,7 +123,7 @@ function buildExtras(folder: "plugins" | "l10n") {
                   : customModuleNames[fileName] || fileName,
             });
           }),
-        ...(css_paths.map(p => fs.copy(p, p.replace("src", "dist"))) as any),
+        ...(cssPaths.map(p => fs.copy(p, p.replace("src", "dist"))) as any),
       ]);
     } catch (err) {
       logErr(err);
@@ -139,7 +139,7 @@ async function transpileStyle(src: string, compress = false) {
       .include(`${__dirname}/src/style`)
       .include(`${__dirname}/src/style/themes`)
       .use(
-        stylus_autoprefixer({
+        stylusAutoprefixer({
           browsers: pkg.browserslist,
         })
       )
@@ -151,7 +151,7 @@ async function transpileStyle(src: string, compress = false) {
 
 async function buildStyle() {
   try {
-    const [src, src_ie] = await Promise.all([
+    const [src, srcIE] = await Promise.all([
       readFileAsync(paths.style),
       readFileAsync("./src/style/ie.styl"),
     ]);
@@ -159,7 +159,7 @@ async function buildStyle() {
     await Promise.all([
       fs.writeFile("./dist/flatpickr.css", await transpileStyle(src)),
       fs.writeFile("./dist/flatpickr.min.css", await transpileStyle(src, true)),
-      fs.writeFile("./dist/ie.css", await transpileStyle(src_ie)),
+      fs.writeFile("./dist/ie.css", await transpileStyle(srcIE)),
     ]);
   } catch (e) {
     logErr(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,21 +280,21 @@ function FlatpickrInstance(
     let seconds = self.config.defaultSeconds;
 
     if (self.config.minDate !== undefined) {
-      const min_hr = self.config.minDate.getHours();
-      const min_minutes = self.config.minDate.getMinutes();
-      hours = Math.max(hours, min_hr);
-      if (hours === min_hr) minutes = Math.max(min_minutes, minutes);
-      if (hours === min_hr && minutes === min_minutes)
+      const minHr = self.config.minDate.getHours();
+      const minMinutes = self.config.minDate.getMinutes();
+      hours = Math.max(hours, minHr);
+      if (hours === minHr) minutes = Math.max(minMinutes, minutes);
+      if (hours === minHr && minutes === minMinutes)
         seconds = self.config.minDate.getSeconds();
     }
 
     if (self.config.maxDate !== undefined) {
-      const max_hr = self.config.maxDate.getHours();
-      const max_minutes = self.config.maxDate.getMinutes();
-      hours = Math.min(hours, max_hr);
+      const maxHr = self.config.maxDate.getHours();
+      const maxMinutes = self.config.maxDate.getMinutes();
+      hours = Math.min(hours, maxHr);
 
-      if (hours === max_hr) minutes = Math.min(max_minutes, minutes);
-      if (hours === max_hr && minutes === max_minutes)
+      if (hours === maxHr) minutes = Math.min(maxMinutes, minutes);
+      if (hours === maxHr && minutes === maxMinutes)
         seconds = self.config.maxDate.getSeconds();
     }
 
@@ -1251,8 +1251,8 @@ function FlatpickrInstance(
     };
   }
 
-  function changeMonth(value: number, is_offset = true) {
-    const delta = is_offset ? value : value - self.currentMonth;
+  function changeMonth(value: number, isOffset = true) {
+    const delta = isOffset ? value : value - self.currentMonth;
 
     if (
       (delta < 0 && self._hidePrevMonthArrow === true) ||
@@ -2873,6 +2873,7 @@ if (typeof jQuery !== "undefined") {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/camelcase
 Date.prototype.fp_incr = function(days: number | string) {
   return new Date(
     this.getFullYear(),

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -89,8 +89,8 @@ export type Instance = Elements &
     // Methods
     changeMonth: (
       value: number,
-      is_offset?: boolean,
-      from_keyboard?: boolean
+      isOffset?: boolean,
+      fromKeyboard?: boolean
     ) => void;
     changeYear: (year: number) => void;
     clear: (emitChangeEvent?: boolean, toInitial?: boolean) => void;

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -51,7 +51,7 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
   const locale = customLocale || l10n;
 
   let parsedDate: Date | undefined;
-  const date_orig = date;
+  const dateOrig = date;
 
   if (date instanceof Date) parsedDate = new Date(date.getTime());
   else if (
@@ -113,7 +113,7 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
 
   /* istanbul ignore next */
   if (!(parsedDate instanceof Date && !isNaN(parsedDate.getTime()))) {
-    config.errorHandler(new Error(`Invalid date provided: ${date_orig}`));
+    config.errorHandler(new Error(`Invalid date provided: ${dateOrig}`));
     return undefined;
   }
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -27,7 +27,7 @@ export type token =
   | "w"
   | "y";
 
-const do_nothing = (): undefined => undefined;
+const doNothing = (): undefined => undefined;
 
 export const monthToStr = (
   monthNumber: number,
@@ -42,7 +42,7 @@ export type RevFormatFn = (
 ) => Date | void | undefined;
 export type RevFormat = Record<string, RevFormatFn>;
 export const revFormat: RevFormat = {
-  D: do_nothing,
+  D: doNothing,
   F: function(dateObj: Date, monthName: string, locale: Locale) {
     dateObj.setMonth(locale.months.longhand.indexOf(monthName));
   },
@@ -101,7 +101,7 @@ export const revFormat: RevFormat = {
   j: (dateObj: Date, day: string) => {
     dateObj.setDate(parseFloat(day));
   },
-  l: do_nothing,
+  l: doNothing,
   m: (dateObj: Date, month: string) => {
     dateObj.setMonth(parseFloat(month) - 1);
   },
@@ -113,7 +113,7 @@ export const revFormat: RevFormat = {
   },
   u: (_: Date, unixMillSeconds: string) =>
     new Date(parseFloat(unixMillSeconds)),
-  w: do_nothing,
+  w: doNothing,
   y: (dateObj: Date, year: string) => {
     dateObj.setFullYear(2000 + parseFloat(year));
   },


### PR DESCRIPTION
time_24hr is a pain point
My take is to change the Locale types to time24hr as that removes a lot of violations and exempt the rest.
Ultimately I think a config option time24hr would be more consistent with the rest of the options but that would break a lot of people.
I think the Locale types are internal only so it just means anyone that creates a new locale can use time24hr but I don't see that being a problem.

I have taken care to keep the Interfaces and config parsing the same.

I noticed which is bad performance wise

https://github.com/flatpickr/flatpickr/blob/eff1511a4581a969341d2f510ad13184e820a3ec/src/index.ts#L2876

#1498