### PR TITLE
Fix @typescript-eslint/no-non-null-assertion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports =  {
       '@typescript-eslint/explicit-function-return-type': 'none,',
       '@typescript-eslint/no-explicit-any': 'none',
       '@typescript-eslint/prefer-interface': 'none',
-      '@typescript-eslint/no-non-null-assertion': 'none',
       '@typescript-eslint/no-object-literal-type-assertion': 'none',
       '@typescript-eslint/camelcase': ['error', { allow: ['time_24hr', 'zh_tw'] }],
     },

--- a/build.ts
+++ b/build.ts
@@ -69,6 +69,7 @@ function uglify(src: string) {
 
 async function buildFlatpickrJs() {
   const bundle = await rollup.rollup(rollupConfig);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return bundle.write(rollupConfig.output!);
 }
 
@@ -218,6 +219,7 @@ function watch(path: string, cb: (path: string) => void) {
 
 async function start() {
   if (DEV_MODE) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     rollupConfig.output!.sourcemap = true;
     const indexExists = await fs.pathExists("./index.html");
     if (!indexExists) {
@@ -241,6 +243,7 @@ async function start() {
 
     function logEvent(e: RollupWatchEvent) {
       write(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         [e.code, e.input && `${e.input} -> ${e.output!}`, "\n"]
           .filter(x => x)
           .join(" ")

--- a/config/rollup.ts
+++ b/config/rollup.ts
@@ -25,6 +25,7 @@ export const getConfig = (opts?: { dev: boolean }): RollupOptions => ({
     else if (
       warning.code !== "CIRCULAR_DEPENDENCY" ||
       !warning.importer ||
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       !ignoredCircular.includes(warning.importer!)
     ) {
       throw Error(warning.message);

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1428,14 +1428,19 @@ describe("flatpickr", () => {
       const monthsDropdown = fp.calendarContainer.querySelector(
         ".flatpickr-monthDropdown-months"
       );
-      const months = monthsDropdown!.querySelectorAll(
+
+      expect(monthsDropdown).toBeTruthy();
+      if (!monthsDropdown) return;
+
+      const months = monthsDropdown.querySelectorAll(
         ".flatpickr-monthDropdown-month"
       );
 
       expect(months.length).toEqual(8);
+      if (months.length != 8) return;
 
-      expect(months[0]!.innerHTML).toEqual("May");
-      expect(months[7]!.innerHTML).toEqual("December");
+      expect(months[0].innerHTML).toEqual("May");
+      expect(months[7].innerHTML).toEqual("December");
     });
 
     it("dropdown should correctly load months with maxDate", () => {
@@ -1447,14 +1452,19 @@ describe("flatpickr", () => {
       const monthsDropdown = fp.calendarContainer.querySelector(
         ".flatpickr-monthDropdown-months"
       );
-      const months = monthsDropdown!.querySelectorAll(
+
+      expect(monthsDropdown).toBeTruthy();
+      if (!monthsDropdown) return;
+
+      const months = monthsDropdown.querySelectorAll(
         ".flatpickr-monthDropdown-month"
       );
 
       expect(months.length).toEqual(9);
+      if (months.length != 9) return;
 
-      expect(months[0]!.innerHTML).toEqual("January");
-      expect(months[months.length - 1]!.innerHTML).toEqual("September");
+      expect(months[0].innerHTML).toEqual("January");
+      expect(months[months.length - 1].innerHTML).toEqual("September");
     });
 
     it("dropdown should change month", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1342,8 +1342,8 @@ function FlatpickrInstance(
 
         if (wrapper.parentNode) {
           while (wrapper.firstChild)
-            wrapper.parentNode!.insertBefore(wrapper.firstChild, wrapper);
-          wrapper.parentNode!.removeChild(wrapper);
+            wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+          wrapper.parentNode.removeChild(wrapper);
         }
       } else
         self.calendarContainer.parentNode.removeChild(self.calendarContainer);
@@ -1683,7 +1683,8 @@ function FlatpickrInstance(
             }
           } else if (
             !self.config.noCalendar &&
-            self.daysContainer!.contains(e.target as Node) &&
+            self.daysContainer &&
+            self.daysContainer.contains(e.target as Node) &&
             e.shiftKey
           ) {
             e.preventDefault();
@@ -1740,16 +1741,14 @@ function FlatpickrInstance(
         true
       ) as Date).getTime(),
       rangeStartDate = Math.min(hoverDate, self.selectedDates[0].getTime()),
-      rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime()),
-      lastDate = (self.daysContainer!.lastChild!
-        .lastChild as DayElement).dateObj.getTime();
+      rangeEndDate = Math.max(hoverDate, self.selectedDates[0].getTime());
 
     let containsDisabled = false;
 
     let minRange = 0,
       maxRange = 0;
 
-    for (let t = rangeStartDate; t < lastDate; t += duration.DAY) {
+    for (let t = rangeStartDate; t < rangeEndDate; t += duration.DAY) {
       if (!isEnabled(new Date(t), true)) {
         containsDisabled =
           containsDisabled || (t > rangeStartDate && t < rangeEndDate);
@@ -2734,9 +2733,9 @@ function FlatpickrInstance(
         self.l10n.amPM[int(self.amPM.textContent === self.l10n.amPM[0])];
     }
 
-    const min = parseFloat(input.getAttribute("min")!),
-      max = parseFloat(input.getAttribute("max")!),
-      step = parseFloat(input.getAttribute("step")!),
+    const min = parseFloat(input.getAttribute("min") as string),
+      max = parseFloat(input.getAttribute("max") as string),
+      step = parseFloat(input.getAttribute("step") as string),
       curValue = parseInt(input.value, 10),
       delta =
         (e as IncrementEvent).delta ||

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -138,40 +138,44 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         return;
       }
 
-      const currentlySelected = fp.rContainer!.querySelector(
+      if (!fp.rContainer || !self.monthsContainer) return;
+
+      const currentlySelected = fp.rContainer.querySelector(
         ".flatpickr-monthSelect-month.selected"
       ) as HTMLElement;
 
       let index = Array.prototype.indexOf.call(
-        self.monthsContainer!.children,
+        self.monthsContainer.children,
         document.activeElement
       );
 
       if (index === -1) {
         const target =
-          currentlySelected || self.monthsContainer!.firstElementChild;
+          currentlySelected || self.monthsContainer.firstElementChild;
         target.focus();
         index = (target as MonthElement).$i;
       }
 
       if (shouldMove) {
-        (self.monthsContainer!.children[
+        (self.monthsContainer.children[
           (12 + index + shifts[e.keyCode]) % 12
         ] as HTMLElement).focus();
       } else if (
         e.keyCode === 13 &&
-        self.monthsContainer!.contains(document.activeElement)
+        self.monthsContainer.contains(document.activeElement)
       ) {
         setMonth((document.activeElement as MonthElement).dateObj);
       }
     }
 
     function destroyPluginInstance() {
-      self
-        .monthsContainer!.querySelectorAll(".flatpickr-monthSelect-month")
-        .forEach(element => {
-          element.removeEventListener("click", selectMonth);
-        });
+      if (self.monthsContainer !== null) {
+        self.monthsContainer
+          .querySelectorAll(".flatpickr-monthSelect-month")
+          .forEach(element => {
+            element.removeEventListener("click", selectMonth);
+          });
+      }
     }
 
     return {

--- a/src/plugins/monthSelect/tests.spec.ts
+++ b/src/plugins/monthSelect/tests.spec.ts
@@ -53,6 +53,10 @@ describe("monthSelect", () => {
     }) as Instance;
 
     expect(fp.input.value).toEqual("03.19");
-    expect(fp.altInput!.value).toEqual("03 19");
+
+    expect(fp.altInput).toBeDefined();
+    if (!fp.altInput) return;
+
+    expect(fp.altInput.value).toEqual("03 19");
   });
 });


### PR DESCRIPTION
- Please check `lastDate` variable that I removed.  I checked and I couldn't see any point looping past `rangeEndRange` but I could be wrong.  Could also be a minor performance improvement for multi month range

- I noticed there is a few examples in the code that use type assertions to circumvent the null issues when collecting config from dom attributes.

- In this PR I did use it myself for the attributes of the time inputs which will result in a NaN if the attribute is missing which is not a bad solution but we could go to `self.config` directly for min max step etc which will always be more up to date than the dom.

- Since rollup has an optional output config I just excepted that .

- Most of the changes are in tests.

