### PR TITLE
Calendar does not open on Android Chrome

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -431,7 +431,7 @@ function FlatpickrInstance(
       bind(window, "resize", debouncedResize);
 
     if (window.ontouchstart !== undefined)
-      bind(window.document, "click", documentClick);
+      bind(window.document, "touchstart", documentClick);
     else bind(window.document, "mousedown", onClick(documentClick));
     bind(window.document, "focus", documentClick, { capture: true });
 


### PR DESCRIPTION
Fixes #1764
Flatpickr doesn't open on mobile chrome version 73+
Replaced click event that was used to handle touch with touchstart to support mobile browsers