### PR TITLE
Fixing unformatted files

### DIFF
--- a/src/l10n/ar.ts
+++ b/src/l10n/ar.ts
@@ -41,7 +41,7 @@ export const Arabic: CustomLocale = {
     ],
   },
 
-  rangeSeparator: ' - ',
+  rangeSeparator: " - ",
 };
 
 fp.l10ns.ar = Arabic;

--- a/src/l10n/id.ts
+++ b/src/l10n/id.ts
@@ -52,7 +52,7 @@ export const Indonesian: CustomLocale = {
     return "";
   },
   time_24hr: true,
-  rangeSeparator: ' - '
+  rangeSeparator: " - ",
 };
 
 fp.l10ns.id = Indonesian;

--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -54,7 +54,7 @@ export const Japanese: CustomLocale = {
     ],
   },
   time_24hr: true,
-  rangeSeparator: ' から ',
+  rangeSeparator: " から ",
 };
 
 fp.l10ns.ja = Japanese;

--- a/src/l10n/ko.ts
+++ b/src/l10n/ko.ts
@@ -58,7 +58,7 @@ export const Korean: CustomLocale = {
     return "일";
   },
 
-  rangeSeparator: ' ~ ',
+  rangeSeparator: " ~ ",
 };
 
 fp.l10ns.ko = Korean;

--- a/src/l10n/vn.ts
+++ b/src/l10n/vn.ts
@@ -55,7 +55,7 @@ export const Vietnamese: CustomLocale = {
   },
 
   firstDayOfWeek: 1,
-  rangeSeparator: ' đến ',
+  rangeSeparator: " đến ",
 };
 
 fp.l10ns.vn = Vietnamese;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,12 +7,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": true,
-    "lib": [
-      "es2015",
-      "dom",
-      "es2017.object",
-      "esnext.asynciterable"
-    ],
+    "lib": ["es2015", "dom", "es2017.object", "esnext.asynciterable"],
     "baseUrl": "./"
   }
 }


### PR DESCRIPTION
When I added the language separators last week, I forgot to run ts-node locally and the files were not auto formatted. Now, every time I try to do anything, it formats the files from then and adds them to my git changeset. This fixes the problem by merging the already formatted files to master