### PR TITLE
#1826 Added monthSelectorType option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -916,7 +916,11 @@ function FlatpickrInstance(
   }
 
   function buildMonthSwitch() {
-    if (self.config.showMonths > 1) return;
+    if (
+      self.config.showMonths > 1 ||
+      self.config.monthSelectorType !== "dropdown"
+    )
+      return;
 
     const shouldBuildMonth = function(month: number): boolean {
       if (
@@ -964,7 +968,10 @@ function FlatpickrInstance(
 
     let monthElement;
 
-    if (self.config.showMonths > 1) {
+    if (
+      self.config.showMonths > 1 ||
+      self.config.monthSelectorType === "static"
+    ) {
       monthElement = createElement<HTMLSpanElement>("span", "cur-month");
     } else {
       self.monthsDropdownContainer = createElement<HTMLSelectElement>(
@@ -2650,7 +2657,10 @@ function FlatpickrInstance(
       const d = new Date(self.currentYear, self.currentMonth, 1);
       d.setMonth(self.currentMonth + i);
 
-      if (self.config.showMonths > 1) {
+      if (
+        self.config.showMonths > 1 ||
+        self.config.monthSelectorType === "static"
+      ) {
         self.monthElements[i].textContent =
           monthToStr(
             d.getMonth(),

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -242,6 +242,9 @@ Use it along with "enableTime" to create a time picker. */
 
   /* See https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements */
   wrap: boolean;
+
+  /* How the month selector in the calendar should be shown */
+  monthSelectorType: "dropdown" | "static";
 }
 
 export type Options = Partial<BaseOptions>;
@@ -312,6 +315,7 @@ export interface ParsedOptions {
   time_24hr: boolean;
   weekNumbers: boolean;
   wrap: boolean;
+  monthSelectorType: string;
 }
 
 export const defaults: ParsedOptions = {
@@ -393,4 +397,5 @@ export const defaults: ParsedOptions = {
   time_24hr: false,
   weekNumbers: false,
   wrap: false,
+  monthSelectorType: "dropdown",
 };

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -164,6 +164,9 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   /* Date selection mode, defaults to "single" */
   mode: "single" | "multiple" | "range" | "time";
 
+  /* How the month selector in the calendar should be shown */
+  monthSelectorType: "dropdown" | "static";
+
   /* HTML for the right arrow icon, used to switch months. */
   nextArrow: string;
 
@@ -242,9 +245,6 @@ Use it along with "enableTime" to create a time picker. */
 
   /* See https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements */
   wrap: boolean;
-
-  /* How the month selector in the calendar should be shown */
-  monthSelectorType: "dropdown" | "static";
 }
 
 export type Options = Partial<BaseOptions>;
@@ -289,6 +289,7 @@ export interface ParsedOptions {
   minTime?: Date;
   minuteIncrement: number;
   mode: BaseOptions["mode"];
+  monthSelectorType: string;
   nextArrow: string;
   noCalendar: boolean;
   now: Date;
@@ -315,7 +316,6 @@ export interface ParsedOptions {
   time_24hr: boolean;
   weekNumbers: boolean;
   wrap: boolean;
-  monthSelectorType: string;
 }
 
 export const defaults: ParsedOptions = {
@@ -370,6 +370,7 @@ export const defaults: ParsedOptions = {
   locale: "default",
   minuteIncrement: 5,
   mode: "single",
+  monthSelectorType: "dropdown",
   nextArrow:
     "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
   noCalendar: false,
@@ -397,5 +398,4 @@ export const defaults: ParsedOptions = {
   time_24hr: false,
   weekNumbers: false,
   wrap: false,
-  monthSelectorType: "dropdown",
 };


### PR DESCRIPTION
Implementes #1826

Flatpickr still defaults to the dropdown, but setting the option to `static` reverts to text representation