### PR TITLE
Fix #1842 In Range mode, click and drag appears to work but then it doesn't

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -444,7 +444,7 @@ function FlatpickrInstance(
       bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
 
       bind(self.monthNav, ["keyup", "increment"], onYearInput);
-      bind(self.daysContainer, "mousedown", onClick(selectDate));
+      bind(self.daysContainer, "click", onClick(selectDate));
     }
 
     if (


### PR DESCRIPTION
This solves the problem described in https://github.com/flatpickr/flatpickr/issues/1842 by disabling the "apparent" click/drag feature by binding to the `click` event instead of the `mousedown` event. Not sure how that fits with code base (given there appears to have been some thought put into using `mousedown` rather than `click`), but it does resolve the problem and make it work as the user would expect.