### PR TITLE
Setting Monday as firstDayOfWeek for Japanese

### DIFF
--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -55,6 +55,7 @@ export const Japanese: CustomLocale = {
   },
   time_24hr: true,
   rangeSeparator: " から ",
+  firstDayOfWeek: 1,
 };
 
 fp.l10ns.ja = Japanese;


### PR DESCRIPTION
Thanks for great library!
First day of a week is Monday in Japan. 😃 