### PR TITLE
Fixed shorthandCurrentMonth not working for month dropdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -947,7 +947,11 @@ function FlatpickrInstance(
       );
 
       month.value = new Date(self.currentYear, i).getMonth().toString();
-      month.textContent = monthToStr(i, false, self.l10n);
+      month.textContent = monthToStr(
+        i,
+        self.config.shorthandCurrentMonth,
+        self.l10n
+      );
       month.tabIndex = -1;
 
       if (self.currentMonth === i) {


### PR DESCRIPTION
Fixes #1856, I forgot to use the shorthand when creating the month name in the dropdown