### PR TITLE
Element div not allowed as child element for span

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -42,7 +42,7 @@ export function createNumberInput(
   inputClassName: string,
   opts?: Record<string, any>
 ) {
-  const wrapper = createElement<HTMLDivElement>("div", "numInputWrapper"),
+  const wrapper = createElement<HTMLDivElement>("span", "numInputWrapper"),
     numInput = createElement<HTMLInputElement>(
       "input",
       "numInput " + inputClassName


### PR DESCRIPTION
Because `div` not allowed inside `span`. This PR adds fix for this.
It's not breaking styles, because in CSS it has inline-block rule already:
`.flatpickr-current-month .numInputWrapper {
    width: 6ch;
    width: 7ch\0;
    display: inline-block;
}`