### PR TITLE
Prefix all CSS classes with "flatpickr-" prefix to avoid conflicts

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -97,7 +97,7 @@ describe("flatpickr", () => {
       const date = new Date("2016-12-27T16:16:22.585Z");
       expect(fp.currentYear).toEqual(date.getFullYear());
       expect(fp.currentMonth).toEqual(date.getMonth());
-      const selected = fp.days.querySelector(".selected");
+      const selected = fp.days.querySelector(".flatpickr-selected");
       expect(selected).toBeTruthy();
 
       if (selected) expect(selected.textContent).toEqual(date.getDate() + "");
@@ -109,7 +109,7 @@ describe("flatpickr", () => {
         defaultDate: "2016-12-27T16:16:22.585Z",
       });
 
-      expect(fp.days.querySelector(".selected")).toEqual(null);
+      expect(fp.days.querySelector(".flatpickr-selected")).toEqual(null);
 
       createInstance({
         defaultDate: "2016-12-27T16:16:22.585Z",
@@ -120,7 +120,7 @@ describe("flatpickr", () => {
       fp.set("minDate", "2016-12-24");
 
       expect(fp.currentMonth).toEqual(11);
-      expect(fp.days.querySelector(".selected")).toEqual(null);
+      expect(fp.days.querySelector(".flatpickr-selected")).toEqual(null);
 
       let enabledDays = fp.days.querySelectorAll(
         ".flatpickr-day:not(.flatpickr-disabled)"
@@ -137,7 +137,7 @@ describe("flatpickr", () => {
       });
 
       expect(fp.selectedDates.length).toBe(0);
-      expect(fp.days.querySelector(".selected")).toEqual(null);
+      expect(fp.days.querySelector(".flatpickr-selected")).toEqual(null);
     });
 
     it("doesn't throw with undefined properties", () => {
@@ -617,7 +617,9 @@ describe("flatpickr", () => {
       fp._input.blur();
 
       expect(fp.isOpen).toBe(false);
-      expect(fp.calendarContainer.classList.contains("open")).toBe(false);
+      expect(fp.calendarContainer.classList.contains("flatpickr-open")).toBe(
+        false
+      );
 
       expect(fp.selectedDates.length).toBe(0);
       simulate("focus", fp._input);
@@ -787,7 +789,9 @@ describe("flatpickr", () => {
         static: true,
       });
 
-      expect(fp.calendarContainer.classList.contains("static")).toBe(true);
+      expect(fp.calendarContainer.classList.contains("flatpickr-static")).toBe(
+        true
+      );
       if (!fp.element.parentNode) return;
       expect(
         (fp.element.parentNode as Element).classList.contains(
@@ -1309,27 +1313,31 @@ describe("flatpickr", () => {
       expect(fp.selectedDates.length).toEqual(1);
 
       simulate("mouseover", fp.days.childNodes[32]);
-      expect(day(21).classList.contains("startRange")).toEqual(true);
+      expect(day(21).classList.contains("flatpickr-startRange")).toEqual(true);
 
       for (let i = 0; i < 42; i++)
-        expect(day(i).classList.contains("inRange")).toEqual(i > 21 && i < 32);
+        expect(day(i).classList.contains("flatpickr-inRange")).toEqual(
+          i > 21 && i < 32
+        );
 
-      expect(day(32).classList.contains("endRange")).toEqual(true);
+      expect(day(32).classList.contains("flatpickr-endRange")).toEqual(true);
 
       fp.clear();
       fp.set("disable", ["2016-1-12", "2016-1-20"]);
       fp.setDate("2016-1-17");
 
       simulate("mouseover", day(32));
-      expect(day(32).classList.contains("endRange")).toEqual(false);
+      expect(day(32).classList.contains("flatpickr-endRange")).toEqual(false);
       expect(day(24).classList.contains("flatpickr-disabled")).toEqual(true);
-      expect(day(25).classList.contains("notAllowed")).toEqual(true);
+      expect(day(25).classList.contains("flatpickr-notAllowed")).toEqual(true);
 
       for (let i = 25; i < 32; i++)
-        expect(day(i).classList.contains("inRange")).toEqual(false);
+        expect(day(i).classList.contains("flatpickr-inRange")).toEqual(false);
 
       for (let i = 17; i < 22; i++) {
-        expect(day(i).classList.contains("notAllowed")).toEqual(false);
+        expect(day(i).classList.contains("flatpickr-notAllowed")).toEqual(
+          false
+        );
         expect(day(i).classList.contains("flatpickr-disabled")).toEqual(false);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,14 @@ import {
 import { Locale, CustomLocale, key as LocaleKey } from "./types/locale";
 import English from "./l10n/default";
 
-import { arrayify, debounce, int, pad, IncrementEvent } from "./utils";
+import {
+  arrayify,
+  cssClassPrefix,
+  debounce,
+  int,
+  pad,
+  IncrementEvent,
+} from "./utils";
 import {
   clearNode,
   createElement,
@@ -530,10 +537,12 @@ function FlatpickrInstance(
    * @param {Event} e the click event
    */
   function timeIncrement(e: KeyboardEvent | MouseEvent) {
-    if (~(e.target as Element).className.indexOf("arrow"))
+    if (~(e.target as Element).className.indexOf(`${cssClassPrefix}arrow`))
       incrementNumInput(
         e,
-        (e.target as Element).classList.contains("arrowUp") ? 1 : -1
+        (e.target as Element).classList.contains(`${cssClassPrefix}arrowUp`)
+          ? 1
+          : -1
       );
   }
 
@@ -564,7 +573,7 @@ function FlatpickrInstance(
     const fragment = window.document.createDocumentFragment();
     self.calendarContainer = createElement<HTMLDivElement>(
       "div",
-      "flatpickr-calendar"
+      `${cssClassPrefix}calendar`
     );
     self.calendarContainer.tabIndex = -1;
 
@@ -572,7 +581,7 @@ function FlatpickrInstance(
       fragment.appendChild(buildMonthNav());
       self.innerContainer = createElement<HTMLDivElement>(
         "div",
-        "flatpickr-innerContainer"
+        `${cssClassPrefix}innerContainer`
       );
 
       if (self.config.weekNumbers) {
@@ -584,14 +593,14 @@ function FlatpickrInstance(
 
       self.rContainer = createElement<HTMLDivElement>(
         "div",
-        "flatpickr-rContainer"
+        `${cssClassPrefix}rContainer`
       );
       self.rContainer.appendChild(buildWeekdays());
 
       if (!self.daysContainer) {
         self.daysContainer = createElement<HTMLDivElement>(
           "div",
-          "flatpickr-days"
+          `${cssClassPrefix}days`
         );
         self.daysContainer.tabIndex = -1;
       }
@@ -609,19 +618,19 @@ function FlatpickrInstance(
 
     toggleClass(
       self.calendarContainer,
-      "rangeMode",
+      `${cssClassPrefix}rangeMode`,
       self.config.mode === "range"
     );
 
     toggleClass(
       self.calendarContainer,
-      "animate",
+      `${cssClassPrefix}animate`,
       self.config.animate === true
     );
 
     toggleClass(
       self.calendarContainer,
-      "multiMonth",
+      `${cssClassPrefix}multiMonth`,
       self.config.showMonths > 1
     );
 
@@ -633,7 +642,9 @@ function FlatpickrInstance(
 
     if (self.config.inline || self.config.static) {
       self.calendarContainer.classList.add(
-        self.config.inline ? "inline" : "static"
+        self.config.inline
+          ? `${cssClassPrefix}inline`
+          : `${cssClassPrefix}static`
       );
 
       if (self.config.inline) {
@@ -647,7 +658,7 @@ function FlatpickrInstance(
       }
 
       if (self.config.static) {
-        const wrapper = createElement("div", "flatpickr-wrapper");
+        const wrapper = createElement("div", `${cssClassPrefix}wrapper`);
         if (self.element.parentNode)
           self.element.parentNode.insertBefore(wrapper, self.element);
         wrapper.appendChild(self.element);
@@ -674,7 +685,7 @@ function FlatpickrInstance(
     const dateIsEnabled = isEnabled(date, true),
       dayElement = createElement<DayElement>(
         "span",
-        "flatpickr-day " + className,
+        `${cssClassPrefix}day ${className}`,
         date.getDate().toString()
       );
 
@@ -686,56 +697,57 @@ function FlatpickrInstance(
     );
 
     if (
-      className.indexOf("hidden") === -1 &&
+      className.indexOf(`${cssClassPrefix}hidden`) === -1 &&
       compareDates(date, self.now) === 0
     ) {
       self.todayDateElem = dayElement;
-      dayElement.classList.add("today");
+      dayElement.classList.add(`${cssClassPrefix}today`);
       dayElement.setAttribute("aria-current", "date");
     }
 
     if (dateIsEnabled) {
       dayElement.tabIndex = -1;
       if (isDateSelected(date)) {
-        dayElement.classList.add("selected");
+        dayElement.classList.add(`${cssClassPrefix}selected`);
         self.selectedDateElem = dayElement;
 
         if (self.config.mode === "range") {
           toggleClass(
             dayElement,
-            "startRange",
+            `${cssClassPrefix}startRange`,
             self.selectedDates[0] &&
               compareDates(date, self.selectedDates[0], true) === 0
           );
 
           toggleClass(
             dayElement,
-            "endRange",
+            `${cssClassPrefix}endRange`,
             self.selectedDates[1] &&
               compareDates(date, self.selectedDates[1], true) === 0
           );
 
-          if (className === "nextMonthDay") dayElement.classList.add("inRange");
+          if (className === `${cssClassPrefix}nextMonthDay`)
+            dayElement.classList.add(`${cssClassPrefix}inRange`);
         }
       }
     } else {
-      dayElement.classList.add("flatpickr-disabled");
+      dayElement.classList.add(`${cssClassPrefix}disabled`);
     }
 
     if (self.config.mode === "range") {
       if (isDateInRange(date) && !isDateSelected(date))
-        dayElement.classList.add("inRange");
+        dayElement.classList.add(`${cssClassPrefix}inRange`);
     }
 
     if (
       self.weekNumbers &&
       self.config.showMonths === 1 &&
-      className !== "prevMonthDay" &&
+      className !== `${cssClassPrefix}prevMonthDay` &&
       dayNumber % 7 === 1
     ) {
       self.weekNumbers.insertAdjacentHTML(
         "beforeend",
-        "<span class='flatpickr-day'>" + self.config.getWeek(date) + "</span>"
+        `<span class='${cssClassPrefix}day'>${self.config.getWeek(date)}</span>`
       );
     }
 
@@ -760,7 +772,10 @@ function FlatpickrInstance(
 
       for (let i = startIndex; i != endIndex; i += delta) {
         const c = month.children[i] as DayElement;
-        if (c.className.indexOf("hidden") === -1 && isEnabled(c.dateObj))
+        if (
+          c.className.indexOf(`${cssClassPrefix}hidden`) === -1 &&
+          isEnabled(c.dateObj)
+        )
           return c;
       }
     }
@@ -796,7 +811,7 @@ function FlatpickrInstance(
       ) {
         const c = month.children[i] as DayElement;
         if (
-          c.className.indexOf("hidden") === -1 &&
+          c.className.indexOf(`${cssClassPrefix}hidden`) === -1 &&
           isEnabled(c.dateObj) &&
           Math.abs(current.$i - i) >= Math.abs(delta)
         )
@@ -838,8 +853,12 @@ function FlatpickrInstance(
     const daysInMonth = self.utils.getDaysInMonth(month),
       days = window.document.createDocumentFragment(),
       isMultiMonth = self.config.showMonths > 1,
-      prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-      nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      prevMonthDayClass = isMultiMonth
+        ? `${cssClassPrefix}prevMonthDay ${cssClassPrefix}hidden`
+        : `${cssClassPrefix}prevMonthDay`,
+      nextMonthDayClass = isMultiMonth
+        ? `${cssClassPrefix}nextMonthDay ${cssClassPrefix}hidden`
+        : `${cssClassPrefix}nextMonthDay`;
 
     let dayNumber = prevMonthDays + 1 - firstOfMonth,
       dayIndex = 0;
@@ -882,7 +901,10 @@ function FlatpickrInstance(
 
     //updateNavigationCurrentMonth();
 
-    const dayContainer = createElement<HTMLDivElement>("div", "dayContainer");
+    const dayContainer = createElement<HTMLDivElement>(
+      "div",
+      `${cssClassPrefix}dayContainer`
+    );
     dayContainer.appendChild(days);
 
     return dayContainer;
@@ -947,7 +969,7 @@ function FlatpickrInstance(
 
       const month = createElement<HTMLOptionElement>(
         "option",
-        "flatpickr-monthDropdown-month"
+        `${cssClassPrefix}monthDropdown-month`
       );
 
       month.value = new Date(self.currentYear, i).getMonth().toString();
@@ -967,7 +989,7 @@ function FlatpickrInstance(
   }
 
   function buildMonth() {
-    const container = createElement("div", "flatpickr-month");
+    const container = createElement("div", `${cssClassPrefix}month`);
     const monthNavFragment = window.document.createDocumentFragment();
 
     let monthElement;
@@ -976,11 +998,14 @@ function FlatpickrInstance(
       self.config.showMonths > 1 ||
       self.config.monthSelectorType === "static"
     ) {
-      monthElement = createElement<HTMLSpanElement>("span", "cur-month");
+      monthElement = createElement<HTMLSpanElement>(
+        "span",
+        `${cssClassPrefix}cur-month`
+      );
     } else {
       self.monthsDropdownContainer = createElement<HTMLSelectElement>(
         "select",
-        "flatpickr-monthDropdown-months"
+        `${cssClassPrefix}monthDropdown-months`
       );
 
       bind(self.monthsDropdownContainer, "change", (e: Event) => {
@@ -997,7 +1022,9 @@ function FlatpickrInstance(
       monthElement = self.monthsDropdownContainer;
     }
 
-    const yearInput = createNumberInput("cur-year", { tabindex: "-1" });
+    const yearInput = createNumberInput(`${cssClassPrefix}cur-year`, {
+      tabindex: "-1",
+    });
 
     const yearElement = yearInput.getElementsByTagName(
       "input"
@@ -1024,7 +1051,7 @@ function FlatpickrInstance(
 
     const currentMonth = createElement<HTMLDivElement>(
       "div",
-      "flatpickr-current-month"
+      `${cssClassPrefix}current-month`
     );
     currentMonth.appendChild(monthElement);
     currentMonth.appendChild(yearInput);
@@ -1059,17 +1086,20 @@ function FlatpickrInstance(
   }
 
   function buildMonthNav() {
-    self.monthNav = createElement<HTMLDivElement>("div", "flatpickr-months");
+    self.monthNav = createElement<HTMLDivElement>(
+      "div",
+      `${cssClassPrefix}months`
+    );
     self.yearElements = [];
     self.monthElements = [];
 
     self.prevMonthNav = createElement<HTMLSpanElement>(
       "span",
-      "flatpickr-prev-month"
+      `${cssClassPrefix}prev-month`
     );
     self.prevMonthNav.innerHTML = self.config.prevArrow;
 
-    self.nextMonthNav = createElement("span", "flatpickr-next-month");
+    self.nextMonthNav = createElement("span", `${cssClassPrefix}next-month`);
     self.nextMonthNav.innerHTML = self.config.nextArrow;
 
     buildMonths();
@@ -1078,7 +1108,7 @@ function FlatpickrInstance(
       get: () => self.__hidePrevMonthArrow,
       set(bool: boolean) {
         if (self.__hidePrevMonthArrow !== bool) {
-          toggleClass(self.prevMonthNav, "flatpickr-disabled", bool);
+          toggleClass(self.prevMonthNav, `${cssClassPrefix}disabled`, bool);
           self.__hidePrevMonthArrow = bool;
         }
       },
@@ -1088,7 +1118,7 @@ function FlatpickrInstance(
       get: () => self.__hideNextMonthArrow,
       set(bool: boolean) {
         if (self.__hideNextMonthArrow !== bool) {
-          toggleClass(self.nextMonthNav, "flatpickr-disabled", bool);
+          toggleClass(self.nextMonthNav, `${cssClassPrefix}disabled`, bool);
           self.__hideNextMonthArrow = bool;
         }
       },
@@ -1102,22 +1132,29 @@ function FlatpickrInstance(
   }
 
   function buildTime() {
-    self.calendarContainer.classList.add("hasTime");
+    self.calendarContainer.classList.add(`${cssClassPrefix}hasTime`);
     if (self.config.noCalendar)
-      self.calendarContainer.classList.add("noCalendar");
+      self.calendarContainer.classList.add(`${cssClassPrefix}noCalendar`);
 
-    self.timeContainer = createElement<HTMLDivElement>("div", "flatpickr-time");
+    self.timeContainer = createElement<HTMLDivElement>(
+      "div",
+      `${cssClassPrefix}time`
+    );
     self.timeContainer.tabIndex = -1;
-    const separator = createElement("span", "flatpickr-time-separator", ":");
+    const separator = createElement(
+      "span",
+      `${cssClassPrefix}time-separator`,
+      ":"
+    );
 
-    const hourInput = createNumberInput("flatpickr-hour", {
+    const hourInput = createNumberInput(`${cssClassPrefix}hour`, {
       "aria-label": self.l10n.hourAriaLabel,
     });
     self.hourElement = hourInput.getElementsByTagName(
       "input"
     )[0] as HTMLInputElement;
 
-    const minuteInput = createNumberInput("flatpickr-minute", {
+    const minuteInput = createNumberInput(`${cssClassPrefix}minute`, {
       "aria-label": self.l10n.minuteAriaLabel,
     });
 
@@ -1157,12 +1194,13 @@ function FlatpickrInstance(
     self.timeContainer.appendChild(separator);
     self.timeContainer.appendChild(minuteInput);
 
-    if (self.config.time_24hr) self.timeContainer.classList.add("time24hr");
+    if (self.config.time_24hr)
+      self.timeContainer.classList.add(`${cssClassPrefix}time24hr`);
 
     if (self.config.enableSeconds) {
-      self.timeContainer.classList.add("hasSeconds");
+      self.timeContainer.classList.add(`${cssClassPrefix}hasSeconds`);
 
-      const secondInput = createNumberInput("flatpickr-second");
+      const secondInput = createNumberInput(`${cssClassPrefix}second`);
       self.secondElement = secondInput.getElementsByTagName(
         "input"
       )[0] as HTMLInputElement;
@@ -1180,7 +1218,7 @@ function FlatpickrInstance(
       self.secondElement.setAttribute("max", "59");
 
       self.timeContainer.appendChild(
-        createElement("span", "flatpickr-time-separator", ":")
+        createElement("span", `${cssClassPrefix}time-separator`, ":")
       );
       self.timeContainer.appendChild(secondInput);
     }
@@ -1189,7 +1227,7 @@ function FlatpickrInstance(
       // add self.amPM if appropriate
       self.amPM = createElement(
         "span",
-        "flatpickr-am-pm",
+        `${cssClassPrefix}am-pm`,
         self.l10n.amPM[
           int(
             (self.latestSelectedDateObj
@@ -1210,14 +1248,14 @@ function FlatpickrInstance(
     if (!self.weekdayContainer)
       self.weekdayContainer = createElement<HTMLDivElement>(
         "div",
-        "flatpickr-weekdays"
+        `${cssClassPrefix}weekdays`
       );
     else clearNode(self.weekdayContainer);
 
     for (let i = self.config.showMonths; i--; ) {
       const container = createElement<HTMLDivElement>(
         "div",
-        "flatpickr-weekdaycontainer"
+        `${cssClassPrefix}weekdaycontainer`
       );
 
       self.weekdayContainer.appendChild(container);
@@ -1241,8 +1279,8 @@ function FlatpickrInstance(
 
     for (let i = self.config.showMonths; i--; ) {
       self.weekdayContainer.children[i].innerHTML = `
-      <span class='flatpickr-weekday'>
-        ${weekdays.join("</span><span class='flatpickr-weekday'>")}
+      <span class='${cssClassPrefix}weekday'>
+        ${weekdays.join(`</span><span class='${cssClassPrefix}weekday'>`)}
       </span>
       `;
     }
@@ -1250,15 +1288,22 @@ function FlatpickrInstance(
 
   /* istanbul ignore next */
   function buildWeeks() {
-    self.calendarContainer.classList.add("hasWeeks");
+    self.calendarContainer.classList.add(`${cssClassPrefix}hasWeeks`);
     const weekWrapper = createElement<HTMLDivElement>(
       "div",
-      "flatpickr-weekwrapper"
+      `${cssClassPrefix}weekwrapper`
     );
     weekWrapper.appendChild(
-      createElement("span", "flatpickr-weekday", self.l10n.weekAbbreviation)
+      createElement(
+        "span",
+        `${cssClassPrefix}weekday`,
+        self.l10n.weekAbbreviation
+      )
     );
-    const weekNumbers = createElement<HTMLDivElement>("div", "flatpickr-weeks");
+    const weekNumbers = createElement<HTMLDivElement>(
+      "div",
+      `${cssClassPrefix}weeks`
+    );
     weekWrapper.appendChild(weekNumbers);
 
     return {
@@ -1323,10 +1368,10 @@ function FlatpickrInstance(
 
     if (!self.isMobile) {
       if (self.calendarContainer !== undefined) {
-        self.calendarContainer.classList.remove("open");
+        self.calendarContainer.classList.remove(`${cssClassPrefix}open`);
       }
       if (self._input !== undefined) {
-        self._input.classList.remove("active");
+        self._input.classList.remove(`${cssClassPrefix}active`);
       }
     }
 
@@ -1374,7 +1419,7 @@ function FlatpickrInstance(
 
     if (self.input) {
       self.input.type = (self.input as any)._type;
-      self.input.classList.remove("flatpickr-input");
+      self.input.classList.remove(`${cssClassPrefix}input`);
       self.input.removeAttribute("readonly");
       self.input.value = "";
     }
@@ -1575,7 +1620,7 @@ function FlatpickrInstance(
   function isInView(elem: Element) {
     if (self.daysContainer !== undefined)
       return (
-        elem.className.indexOf("hidden") === -1 &&
+        elem.className.indexOf(`${cssClassPrefix}hidden`) === -1 &&
         self.daysContainer.contains(elem)
       );
     return false;
@@ -1753,8 +1798,8 @@ function FlatpickrInstance(
     if (
       self.selectedDates.length !== 1 ||
       (elem &&
-        (!elem.classList.contains("flatpickr-day") ||
-          elem.classList.contains("flatpickr-disabled")))
+        (!elem.classList.contains(`${cssClassPrefix}day`) ||
+          elem.classList.contains(`${cssClassPrefix}disabled`)))
     )
       return;
 
@@ -1798,34 +1843,43 @@ function FlatpickrInstance(
           (maxRange > 0 && timestamp > maxRange);
 
         if (outOfRange) {
-          dayElem.classList.add("notAllowed");
-          ["inRange", "startRange", "endRange"].forEach(c => {
+          dayElem.classList.add(`${cssClassPrefix}notAllowed`);
+          [
+            `${cssClassPrefix}inRange`,
+            `${cssClassPrefix}startRange`,
+            `${cssClassPrefix}endRange`,
+          ].forEach(c => {
             dayElem.classList.remove(c);
           });
           continue;
         } else if (containsDisabled && !outOfRange) continue;
 
-        ["startRange", "inRange", "endRange", "notAllowed"].forEach(c => {
+        [
+          `${cssClassPrefix}startRange`,
+          `${cssClassPrefix}inRange`,
+          `${cssClassPrefix}endRange`,
+          `${cssClassPrefix}notAllowed`,
+        ].forEach(c => {
           dayElem.classList.remove(c);
         });
 
         if (elem !== undefined) {
           elem.classList.add(
             hoverDate <= self.selectedDates[0].getTime()
-              ? "startRange"
-              : "endRange"
+              ? `${cssClassPrefix}startRange`
+              : `${cssClassPrefix}endRange`
           );
 
           if (initialDate < hoverDate && timestamp === initialDate)
-            dayElem.classList.add("startRange");
+            dayElem.classList.add(`${cssClassPrefix}startRange`);
           else if (initialDate > hoverDate && timestamp === initialDate)
-            dayElem.classList.add("endRange");
+            dayElem.classList.add(`${cssClassPrefix}endRange`);
           if (
             timestamp >= minRange &&
             (maxRange === 0 || timestamp <= maxRange) &&
             isBetween(timestamp, initialDate, hoverDate)
           )
-            dayElem.classList.add("inRange");
+            dayElem.classList.add(`${cssClassPrefix}inRange`);
         }
       }
     }
@@ -1873,8 +1927,8 @@ function FlatpickrInstance(
     self.isOpen = true;
 
     if (!wasOpen) {
-      self.calendarContainer.classList.add("open");
-      self._input.classList.add("active");
+      self.calendarContainer.classList.add(`${cssClassPrefix}open`);
+      self._input.classList.add(`${cssClassPrefix}active`);
       triggerEvent("onOpen");
       positionCalendar(positionElement);
     }
@@ -2145,8 +2199,16 @@ function FlatpickrInstance(
       inputBounds.top +
       (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
 
-    toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
-    toggleClass(self.calendarContainer, "arrowBottom", showOnTop);
+    toggleClass(
+      self.calendarContainer,
+      `${cssClassPrefix}arrowTop`,
+      !showOnTop
+    );
+    toggleClass(
+      self.calendarContainer,
+      `${cssClassPrefix}arrowBottom`,
+      showOnTop
+    );
 
     if (self.config.inline) return;
 
@@ -2156,11 +2218,17 @@ function FlatpickrInstance(
       (configPosHorizontal != null && configPosHorizontal === "center"
         ? (calendarWidth - inputBounds.width) / 2
         : 0);
-    const right = window.document.body.offsetWidth - (window.pageXOffset + inputBounds.right);
+    const right =
+      window.document.body.offsetWidth -
+      (window.pageXOffset + inputBounds.right);
     const rightMost = left + calendarWidth > window.document.body.offsetWidth;
     const centerMost = right + calendarWidth > window.document.body.offsetWidth;
 
-    toggleClass(self.calendarContainer, "rightMost", rightMost);
+    toggleClass(
+      self.calendarContainer,
+      `${cssClassPrefix}rightMost`,
+      rightMost
+    );
 
     if (self.config.static) return;
 
@@ -2178,12 +2246,12 @@ function FlatpickrInstance(
       if (doc === undefined) return;
       const bodyWidth = window.document.body.offsetWidth;
       const centerLeft = Math.max(0, bodyWidth / 2 - calendarWidth / 2);
-      const centerBefore = ".flatpickr-calendar.centerMost:before";
-      const centerAfter = ".flatpickr-calendar.centerMost:after";
+      const centerBefore = `.${cssClassPrefix}calendar.${cssClassPrefix}centerMost:before`;
+      const centerAfter = `.${cssClassPrefix}calendar.${cssClassPrefix}centerMost:after`;
       const centerIndex = doc.cssRules.length;
       const centerStyle = `{left:${inputBounds.left}px;right:auto;}`;
-      toggleClass(self.calendarContainer, "rightMost", false);
-      toggleClass(self.calendarContainer, "centerMost", true);
+      toggleClass(self.calendarContainer, `${cssClassPrefix}rightMost`, false);
+      toggleClass(self.calendarContainer, `${cssClassPrefix}centerMost`, true);
       doc.insertRule(
         `${centerBefore},${centerAfter}${centerStyle}`,
         centerIndex
@@ -2220,9 +2288,9 @@ function FlatpickrInstance(
 
     const isSelectable = (day: Element) =>
       day.classList &&
-      day.classList.contains("flatpickr-day") &&
-      !day.classList.contains("flatpickr-disabled") &&
-      !day.classList.contains("notAllowed");
+      day.classList.contains(`${cssClassPrefix}day`) &&
+      !day.classList.contains(`${cssClassPrefix}disabled`) &&
+      !day.classList.contains(`${cssClassPrefix}notAllowed`);
 
     const t = findParent(e.target as Element, isSelectable);
 
@@ -2504,7 +2572,11 @@ function FlatpickrInstance(
       set(bool: boolean) {
         self._showTimeInput = bool;
         if (self.calendarContainer)
-          toggleClass(self.calendarContainer, "showTimeInput", bool);
+          toggleClass(
+            self.calendarContainer,
+            `${cssClassPrefix}showTimeInput`,
+            bool
+          );
         self.isOpen && positionCalendar();
       },
     });
@@ -2525,7 +2597,7 @@ function FlatpickrInstance(
     (self.input as any)._type = (self.input as any).type;
     (self.input as any).type = "text";
 
-    self.input.classList.add("flatpickr-input");
+    self.input.classList.add(`${cssClassPrefix}input`);
     self._input = self.input;
 
     if (self.config.altInput) {
@@ -2564,7 +2636,7 @@ function FlatpickrInstance(
 
     self.mobileInput = createElement<HTMLInputElement>(
       "input",
-      self.input.className + " flatpickr-mobile"
+      `${self.input.className} ${cssClassPrefix}mobile`
     );
     self.mobileInput.step = self.input.getAttribute("step") || "any";
     self.mobileInput.tabIndex = 1;
@@ -2743,9 +2815,13 @@ function FlatpickrInstance(
       changeMonth(isPrevMonth ? -1 : 1);
     } else if (self.yearElements.indexOf(e.target as HTMLInputElement) >= 0) {
       (e.target as HTMLInputElement).select();
-    } else if ((e.target as Element).classList.contains("arrowUp")) {
+    } else if (
+      (e.target as Element).classList.contains(`${cssClassPrefix}arrowUp`)
+    ) {
       self.changeYear(self.currentYear + 1);
-    } else if ((e.target as Element).classList.contains("arrowDown")) {
+    } else if (
+      (e.target as Element).classList.contains(`${cssClassPrefix}arrowDown`)
+    ) {
       self.changeYear(self.currentYear - 1);
     }
   }

--- a/src/plugins/confirmDate/confirmDate.css
+++ b/src/plugins/confirmDate/confirmDate.css
@@ -13,12 +13,12 @@
 	fill: inherit;
 }
 
-.flatpickr-confirm.darkTheme {
+.flatpickr-confirm.flatpickr-darkTheme {
 	color: white;
 	fill: white;
 }
 
-.flatpickr-confirm.visible {
+.flatpickr-confirm.flatpickr-visible {
 	max-height: 40px;
 	visibility: visible
 }

--- a/src/plugins/confirmDate/confirmDate.ts
+++ b/src/plugins/confirmDate/confirmDate.ts
@@ -1,5 +1,6 @@
 import { Instance } from "../../types/instance";
 import { Plugin } from "../../types/options";
+import { cssClassPrefix } from "../../utils";
 
 export interface Config {
   confirmIcon?: string;
@@ -19,7 +20,7 @@ const defaultConfig: Config = {
 function confirmDatePlugin(pluginConfig: Config): Plugin {
   const config = { ...defaultConfig, ...pluginConfig };
   let confirmContainer: HTMLDivElement;
-  const confirmButtonCSSClass = "flatpickr-confirm";
+  const confirmButtonCSSClass = `${cssClassPrefix}confirm`;
 
   return function(fp: Instance) {
     if (fp.config.noCalendar || fp.isMobile) return {};
@@ -35,9 +36,9 @@ function confirmDatePlugin(pluginConfig: Config): Plugin {
       onReady() {
         confirmContainer = fp._createElement<HTMLDivElement>(
           "div",
-          `${confirmButtonCSSClass} ${config.showAlways ? "visible" : ""} ${
-            config.theme
-          }Theme`,
+          `${confirmButtonCSSClass} ${
+            config.showAlways ? `${cssClassPrefix}visible` : ""
+          } ${cssClassPrefix}${config.theme}Theme`,
           config.confirmText
         );
 
@@ -69,9 +70,13 @@ function confirmDatePlugin(pluginConfig: Config): Plugin {
                 showCondition &&
                 localConfirmContainer
               )
-                return localConfirmContainer.classList.add("visible");
+                return localConfirmContainer.classList.add(
+                  `${cssClassPrefix}visible`
+                );
 
-              localConfirmContainer.classList.remove("visible");
+              localConfirmContainer.classList.remove(
+                `${cssClassPrefix}visible`
+              );
             },
           }
         : {}),

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -1,5 +1,6 @@
 import { Plugin } from "../../types/options";
 import { DayElement as MonthElement, Instance } from "../../types/instance";
+import { cssClassPrefix } from "../../utils";
 import { monthToStr } from "../../utils/formatting";
 
 export interface Config {
@@ -61,19 +62,19 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
 
       self.monthsContainer = fp._createElement<HTMLDivElement>(
         "div",
-        "flatpickr-monthSelect-months"
+        `${cssClassPrefix}monthSelect-months`
       );
 
       self.monthsContainer.tabIndex = -1;
 
       fp.calendarContainer.classList.add(
-        `flatpickr-monthSelect-theme-${config.theme}`
+        `${cssClassPrefix}monthSelect-theme-${config.theme}`
       );
 
       for (let i = 0; i < 12; i++) {
         const month = fp._createElement<MonthElement>(
           "span",
-          "flatpickr-monthSelect-month"
+          `${cssClassPrefix}monthSelect-month`
         );
         month.dateObj = new Date(fp.currentYear, i);
         month.$i = i;
@@ -81,8 +82,11 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         month.tabIndex = -1;
         month.addEventListener("click", selectMonth);
         self.monthsContainer.appendChild(month);
-        if ((fp.config.minDate && month.dateObj < fp.config.minDate) || (fp.config.maxDate && month.dateObj > fp.config.maxDate)) {
-          month.classList.add("disabled");
+        if (
+          (fp.config.minDate && month.dateObj < fp.config.minDate) ||
+          (fp.config.maxDate && month.dateObj > fp.config.maxDate)
+        ) {
+          month.classList.add(`${cssClassPrefix}disabled`);
         }
       }
 
@@ -93,19 +97,19 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       if (!fp.rContainer) return;
 
       const currentlySelected = fp.rContainer.querySelectorAll(
-        ".flatpickr-monthSelect-month.selected"
+        `.${cssClassPrefix}monthSelect-month.${cssClassPrefix}selected`
       );
 
       for (let index = 0; index < currentlySelected.length; index++) {
-        currentlySelected[index].classList.remove("selected");
+        currentlySelected[index].classList.remove(`${cssClassPrefix}selected`);
       }
 
       const month = fp.rContainer.querySelector(
-        `.flatpickr-monthSelect-month:nth-child(${fp.currentMonth + 1})`
+        `.${cssClassPrefix}monthSelect-month:nth-child(${fp.currentMonth + 1})`
       );
 
       if (month) {
-        month.classList.add("selected");
+        month.classList.add(`${cssClassPrefix}selected`);
       }
     }
 
@@ -125,23 +129,30 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         setCurrentlySelected();
       }
       if (fp.rContainer) {
-        const months: NodeListOf<ElementDate> = fp.rContainer.querySelectorAll(".flatpickr-monthSelect-month");
+        const months: NodeListOf<ElementDate> = fp.rContainer.querySelectorAll(
+          `.${cssClassPrefix}monthSelect-month`
+        );
         months.forEach(month => {
           month.dateObj.setFullYear(fp.currentYear);
-          if ((fp.config.minDate && month.dateObj < fp.config.minDate) || (fp.config.maxDate && month.dateObj > fp.config.maxDate)) {
-            month.classList.add("disabled");
+          if (
+            (fp.config.minDate && month.dateObj < fp.config.minDate) ||
+            (fp.config.maxDate && month.dateObj > fp.config.maxDate)
+          ) {
+            month.classList.add(`${cssClassPrefix}disabled`);
           } else {
-            month.classList.remove("disabled");
+            month.classList.remove(`${cssClassPrefix}disabled`);
           }
         });
       }
-      
     }
 
     function selectMonth(e: Event) {
       e.preventDefault();
       e.stopPropagation();
-      if (e.target instanceof Element && !e.target.classList.contains("disabled")) {
+      if (
+        e.target instanceof Element &&
+        !e.target.classList.contains(`${cssClassPrefix}disabled`)
+      ) {
         setMonth((e.target as MonthElement).dateObj);
         fp.close();
       }
@@ -173,7 +184,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       if (!fp.rContainer || !self.monthsContainer) return;
 
       const currentlySelected = fp.rContainer.querySelector(
-        ".flatpickr-monthSelect-month.selected"
+        `.${cssClassPrefix}monthSelect-month.${cssClassPrefix}selected`
       ) as HTMLElement;
 
       let index = Array.prototype.indexOf.call(
@@ -203,7 +214,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     function destroyPluginInstance() {
       if (self.monthsContainer !== null) {
         const months = self.monthsContainer.querySelectorAll(
-          ".flatpickr-monthSelect-month"
+          `.${cssClassPrefix}monthSelect-month`
         );
 
         for (let index = 0; index < months.length; index++) {

--- a/src/plugins/monthSelect/style.css
+++ b/src/plugins/monthSelect/style.css
@@ -24,12 +24,12 @@
   width: 33%;
 }
 
-.flatpickr-monthSelect-month.disabled {
+.flatpickr-monthSelect-month.flatpickr-disabled {
 	color: #eee;
 }
 
-.flatpickr-monthSelect-month.disabled:hover,
-.flatpickr-monthSelect-month.disabled:focus {
+.flatpickr-monthSelect-month.flatpickr-disabled:hover,
+.flatpickr-monthSelect-month.flatpickr-disabled:focus {
 	cursor: not-allowed;
 	background: none !important;
 }
@@ -38,7 +38,7 @@
   background: #3f4458;
 }
 
-.flatpickr-monthSelect-theme-dark .flatpickr-current-month input.cur-year {
+.flatpickr-monthSelect-theme-dark .flatpickr-current-month input.flatpickr-cur-year {
   color: #fff;
 }
 
@@ -65,12 +65,12 @@
   border-color: #646c8c;
 }
 
-.flatpickr-monthSelect-month.selected {
+.flatpickr-monthSelect-month.flatpickr-selected {
   background-color: #569ff7;
   color: #fff;
 }
 
-.flatpickr-monthSelect-theme-dark .flatpickr-monthSelect-month.selected {
+.flatpickr-monthSelect-theme-dark .flatpickr-monthSelect-month.flatpickr-selected {
   background: #80cbc4;
   -webkit-box-shadow: none;
   box-shadow: none;

--- a/src/plugins/weekSelect/weekSelect.ts
+++ b/src/plugins/weekSelect/weekSelect.ts
@@ -1,5 +1,6 @@
 import { DayElement } from "../../types/instance";
 import { Plugin } from "../../types/options";
+import { cssClassPrefix } from "../../utils";
 
 export type PlusWeeks = {
   weekStartDay: Date;
@@ -10,7 +11,7 @@ function weekSelectPlugin(): Plugin<PlusWeeks> {
   return function(fp) {
     function onDayHover(event: MouseEvent) {
       const day = event.target as DayElement;
-      if (!day.classList.contains("flatpickr-day")) return;
+      if (!day.classList.contains(`${cssClassPrefix}day`)) return;
 
       const days = fp.days.childNodes;
       const dayIndex = day.$i;

--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -1,6 +1,6 @@
 @require "./_vars.styl"
 
-@keyframes fpFadeInDown
+@keyframes flatpickr-fadeInDown
   from
     opacity 0
     transform translate3d(0, -20px, 0)
@@ -40,53 +40,53 @@
       0 3px 13px alpha(black, 0.08)
 
 
-  &.open, &.inline
+  &.flatpickr-open, &.flatpickr-inline
     opacity 1
     max-height 640px
     visibility visible
 
-  &.open
+  &.flatpickr-open
     display inline-block
     z-index 99999
 
-  &.animate.open
-    animation fpFadeInDown 300ms $bezier
+  &.flatpickr-animate.flatpickr-open
+    animation flatpickr-fadeInDown 300ms $bezier
 
-  &.inline
+  &.flatpickr-inline
     display block
     position relative
     top 2px
 
-  &.static
+  &.flatpickr-static
     position absolute
     top calc(100% + 2px)
 
-    &.open
+    &.flatpickr-open
       z-index 999
       display block
 
-  &.multiMonth
-    .flatpickr-days .dayContainer:nth-child(n+1)
-      & .flatpickr-day.inRange:nth-child(7n+7)
+  &.flatpickr-multiMonth
+    .flatpickr-days .flatpickr-dayContainer:nth-child(n+1)
+      & .flatpickr-day.flatpickr-inRange:nth-child(7n+7)
         box-shadow: none !important;
 
-    .flatpickr-days .dayContainer:nth-child(n+2)
-      & .flatpickr-day.inRange:nth-child(7n+1)
+    .flatpickr-days .flatpickr-dayContainer:nth-child(n+2)
+      & .flatpickr-day.flatpickr-inRange:nth-child(7n+1)
         box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6
 
 
 
-  .hasWeeks, .hasTime
-    .dayContainer
+  .flatpickr-hasWeeks, .flatpickr-hasTime
+    .flatpickr-dayContainer
       border-bottom 0
       border-bottom-right-radius 0
       border-bottom-left-radius 0
 
   if $noCalendarBorder
-    .hasWeeks .dayContainer
+    .flatpickr-hasWeeks .flatpickr-dayContainer
       border-left 0
 
-  &.showTimeInput.hasTime
+  &.flatpickr-showTimeInput.flatpickr-hasTime
     .flatpickr-time
       height $timeHeight
       border-top 1px solid $calendarBorderColor
@@ -98,7 +98,7 @@
       .flatpickr-time
         border 1px solid $calendarBorderColor
 
-  &.noCalendar.hasTime
+  &.flatpickr-noCalendar.flatpickr-hasTime
     .flatpickr-time
       height auto
 
@@ -112,7 +112,7 @@
     width 0
     left 22px
 
-  &.rightMost
+  &.flatpickr-rightMost
     &:before, &:after
       left auto
       right 22px
@@ -125,7 +125,7 @@
     border-width 4px
     margin 0 -4px
 
-  &.arrowTop
+  &.flatpickr-arrowTop
     &:before, &:after
       bottom 100%
     &:before
@@ -136,7 +136,7 @@
       else
         border-bottom-color $calendarBackground
 
-  &.arrowBottom
+  &.flatpickr-arrowBottom
     &:before, &:after
       top 100%
     &:before
@@ -225,7 +225,7 @@
         fill inherit
 
 
-.numInputWrapper
+.flatpickr-numInputWrapper
   position relative
   height auto
 
@@ -264,7 +264,7 @@
       content ""
       position absolute
 
-    &.arrowUp
+    &.flatpickr-arrowUp
       top 0
       border-bottom 0
 
@@ -274,7 +274,7 @@
         border-bottom 4px solid alpha($dayForeground, 0.6)
         top 26%
 
-    &.arrowDown
+    &.flatpickr-arrowDown
       top 50%
 
       &:after
@@ -311,7 +311,7 @@
   text-align center
   transform translate3d(0px, 0px, 0px)
 
-  span.cur-month
+  span.flatpickr-cur-month
     font-family inherit
     font-weight 700
     color inherit
@@ -323,18 +323,18 @@
       background: alpha($invertedBg, 0.05)
 
 
-  .numInputWrapper
+  .flatpickr-numInputWrapper
     width 6ch
     width unquote("7ch\0")
     display inline-block
 
-    span.arrowUp:after
+    span.flatpickr-arrowUp:after
       border-bottom-color $monthForeground
 
-    span.arrowDown:after
+    span.flatpickr-arrowDown:after
       border-top-color $monthForeground
 
-  input.cur-year
+  input.flatpickr-cur-year
     background transparent
     box-sizing border-box
     color inherit
@@ -425,7 +425,7 @@ span.flatpickr-weekday
   font-weight bolder
 
 
-.dayContainer, .flatpickr-weeks
+.flatpickr-dayContainer, .flatpickr-weeks
   padding 1px 0 0 0
 
 .flatpickr-days
@@ -443,7 +443,7 @@ span.flatpickr-weekday
     border-right 1px solid $calendarBorderColor
 
 
-.dayContainer
+.flatpickr-dayContainer
   padding 0
   outline 0
   text-align left
@@ -461,7 +461,7 @@ span.flatpickr-weekday
   transform: translate3d(0px, 0px, 0px);
   opacity 1
 
-  & + .dayContainer
+  & + .flatpickr-dayContainer
     box-shadow: -1px 0 0 $calendarBorderColor;
 
 
@@ -486,15 +486,15 @@ span.flatpickr-weekday
   justify-content center
   text-align center
 
-  &, &.prevMonthDay, &.nextMonthDay
-    &.inRange, &.today.inRange, &:hover, &:focus
+  &, &.flatpickr-prevMonthDay, &.flatpickr-nextMonthDay
+    &.flatpickr-inRange, &.flatpickr-today.flatpickr-inRange, &:hover, &:focus
       cursor pointer
       outline 0
       background $dayHoverBackground
       border-color $dayHoverBackground
 
 
-  &.today
+  &.flatpickr-today
     border-color $todayColor
 
     &:hover, &:focus
@@ -505,8 +505,8 @@ span.flatpickr-weekday
       else
         color white
 
-  &.selected, &.startRange, &.endRange
-    &, &.inRange, &:focus, &:hover, &.prevMonthDay, &.nextMonthDay
+  &.flatpickr-selected, &.flatpickr-startRange, &.flatpickr-endRange
+    &, &.flatpickr-inRange, &:focus, &:hover, &.flatpickr-prevMonthDay, &.flatpickr-nextMonthDay
       background $selectedDayBackground
       box-shadow none
 
@@ -517,27 +517,27 @@ span.flatpickr-weekday
 
       border-color $selectedDayBackground
 
-    &.startRange
+    &.flatpickr-startRange
       border-radius 50px 0 0 50px
       //box-shadow:  (2.5*$dayMargin) 0 0 $selectedDayBackground
 
-    &.endRange
+    &.flatpickr-endRange
       border-radius 0 50px 50px 0
 
     // Avoid adding extra fill because it overflows in multimonth mode
-    &.startRange + .endRange:not(:nth-child(7n+1))
+    &.flatpickr-startRange + .flatpickr-endRange:not(:nth-child(7n+1))
       box-shadow: (-5*$dayMargin) 0 0 $selectedDayBackground
 
-    &.startRange.endRange
+    &.flatpickr-startRange.flatpickr-endRange
       border-radius 50px
 
-  &.inRange
+  &.flatpickr-inRange
     border-radius 0
     box-shadow: (-2.5*$dayMargin) 0 0 $dayHoverBackground, (2.5*$dayMargin) 0 0 $dayHoverBackground
 
   &.flatpickr-disabled, &.flatpickr-disabled:hover,
-  &.prevMonthDay, &.nextMonthDay,
-  &.notAllowed, &.notAllowed.prevMonthDay, &.notAllowed.nextMonthDay
+  &.flatpickr-prevMonthDay, &.flatpickr-nextMonthDay,
+  &.flatpickr-notAllowed, &.flatpickr-notAllowed.flatpickr-prevMonthDay, &.flatpickr-notAllowed.flatpickr-nextMonthDay
     color alpha($dayForeground, 0.3)
     background transparent
 
@@ -552,15 +552,15 @@ span.flatpickr-weekday
     cursor not-allowed
     color alpha($dayForeground, 0.1)
 
-  &.week.selected
+  &.flatpickr-week.flatpickr-selected
     border-radius 0
     box-shadow: (-2.5*$dayMargin) 0 0 $selectedDayBackground,
       (2.5*$dayMargin) 0 0 $selectedDayBackground
 
-  &.hidden
+  &.flatpickr-hidden
     visibility hidden
 
-.rangeMode .flatpickr-day
+.flatpickr-rangeMode .flatpickr-day
   margin-top 1px
 
 .flatpickr-weekwrapper
@@ -626,22 +626,22 @@ span.flatpickr-weekday
     display table
     clear both
 
-  .numInputWrapper
+  .flatpickr-numInputWrapper
     flex 1
     width 40%
     height $timeHeight
     float left
 
-    span.arrowUp:after
+    span.flatpickr-arrowUp:after
       border-bottom-color $dayForeground
 
-    span.arrowDown:after
+    span.flatpickr-arrowDown:after
       border-top-color $dayForeground
 
-  &.hasSeconds .numInputWrapper
+  &.flatpickr-hasSeconds .flatpickr-numInputWrapper
     width 26%
 
-  &.time24hr .numInputWrapper
+  &.flatpickr-time24hr .flatpickr-numInputWrapper
     width 49%
 
   input

--- a/src/style/themes/airbnb.styl
+++ b/src/style/themes/airbnb.styl
@@ -24,12 +24,12 @@ $selectedDayForeground = #fff
 .flatpickr-calendar
 	width $daysWidth
 
-.dayContainer
+.flatpickr-dayContainer
 	padding 0
 	border-right 0
 
 span.flatpickr-day
-	&, &.prevMonthDay, &.nextMonthDay
+	&, &.flatpickr-prevMonthDay, &.flatpickr-nextMonthDay
 		border-radius 0 !important
 		border 1px solid $dayHoverBackground
 		max-width none
@@ -47,7 +47,7 @@ span.flatpickr-day
 		&:nth-child(-n+7)
 			margin-top 0
 
-		&.today:not(.selected)
+		&.flatpickr-today:not(.flatpickr-selected)
 			border-color $dayHoverBackground
 			border-right-color transparent
 			border-top-color transparent
@@ -56,14 +56,14 @@ span.flatpickr-day
 			&:hover
 				border 1px solid $todayColor
 
-		&.startRange, &.endRange
+		&.flatpickr-startRange, &.flatpickr-endRange
 			border-color $selectedDayBackground
 
 
-		&.today, &.selected
+		&.flatpickr-today, &.flatpickr-selected
 			z-index 2
 
-.rangeMode .flatpickr-day
+.flatpickr-rangeMode .flatpickr-day
 	margin-top -1px
 
 .flatpickr-weekwrapper .flatpickr-weeks
@@ -74,7 +74,7 @@ span.flatpickr-day
 	margin -1px 0 0 -1px
 
 
-.hasWeeks .flatpickr-days
+.flatpickr-hasWeeks .flatpickr-days
 	border-right 0
 
 @css {

--- a/src/style/themes/light.styl
+++ b/src/style/themes/light.styl
@@ -18,5 +18,5 @@ $selectedDayForeground = #fff
 $noCalendarBorder = true
 @require "../flatpickr"
 
-span.flatpickr-day.selected
+span.flatpickr-day.flatpickr-selected
 	font-weight bold

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -14,7 +14,7 @@ import {
 import {
   Locale as _Locale,
   CustomLocale as _CustomLocale,
-  key as _LocaleKey
+  key as _LocaleKey,
 } from "./types/locale";
 
 declare var flatpickr: FlatpickrFn;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,3 +1,5 @@
+import { cssClassPrefix } from "../utils";
+
 export function toggleClass(
   elem: HTMLElement,
   className: string,
@@ -42,13 +44,22 @@ export function createNumberInput(
   inputClassName: string,
   opts?: Record<string, any>
 ) {
-  const wrapper = createElement<HTMLDivElement>("div", "numInputWrapper"),
+  const wrapper = createElement<HTMLDivElement>(
+      "div",
+      `${cssClassPrefix}numInputWrapper`
+    ),
     numInput = createElement<HTMLInputElement>(
       "input",
-      "numInput " + inputClassName
+      `${cssClassPrefix}numInput ${inputClassName}`
     ),
-    arrowUp = createElement<HTMLSpanElement>("span", "arrowUp"),
-    arrowDown = createElement<HTMLSpanElement>("span", "arrowDown");
+    arrowUp = createElement<HTMLSpanElement>(
+      "span",
+      `${cssClassPrefix}arrowUp`
+    ),
+    arrowDown = createElement<HTMLSpanElement>(
+      "span",
+      `${cssClassPrefix}arrowDown`
+    );
 
   if (navigator.userAgent.indexOf("MSIE 9.0") === -1) {
     numInput.type = "number";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export const cssClassPrefix = "flatpickr-";
 export const pad = (number: string | number) => `0${number}`.slice(-2);
 export const int = (bool: boolean) => (bool === true ? 1 : 0);
 


### PR DESCRIPTION
If the page flatpickr is used on has global CSS classes like `.open`, `.inline`, or `.static`, then it's possible Flatpickr's own CSS styles for those same classes can inherit from those global classes and lead to unexpected styling of Flatpickr.

This PR prefixes all the CSS classes used by Flatpickr so they all contain the `flatpickr-` prefix. Some of the CSS classes were already prefixed in this fashion, but a number of helper classes were not. Some of these classes were probably less likely to conflict, but it seems like it could be beneficial to namespace all of the CSS classes for consistency and to avoid any potential conflicts.

This is similar to https://github.com/flatpickr/flatpickr/pull/1719 but basically just applies the same fix across all the CSS classes, not just the `disabled` class.

This could represent a slight compatibility issue if some of these CSS classes had been customized by custom stylesheets in your own application (theoretically #1719 could have also had the same issue, but it was probably less likely for that single class). So I'm not sure if that represents a problem, or if it's worth flagging in the changelog if this gets merged in.

I attempted to make this as consistent as possible by using a constant variable for the prefix in the TypeScript code. In the CSS code, I manually made the necessary changes, but one other possible option would be to use Stylus's [`prefix-classes` function](http://stylus-lang.com/docs/bifs.html#prefix-classesprefix), I just wasn't sure it that would be as obvious.

Happy to discuss any of this further. Thanks!