### PR TITLE
Allow keyboard navigation when using altInput

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1672,7 +1672,8 @@ function FlatpickrInstance(
           const delta = e.keyCode === 40 ? 1 : -1;
           if (
             (self.daysContainer && (e.target as DayElement).$i !== undefined) ||
-            e.target === self.input
+            e.target === self.input ||
+            e.target === self.altInput
           ) {
             if (e.ctrlKey) {
               e.stopPropagation();


### PR DESCRIPTION
Fixes #1887, or at least part of it.

The logic for pressing up/down arrow keys when the input is active didn't take the altInput element into account.