### PR TITLE
Only update weekdayContainer when initialized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1229,6 +1229,10 @@ function FlatpickrInstance(
   }
 
   function updateWeekdays() {
+    if (!self.weekdayContainer) {
+      return;
+    }
+
     const firstDayOfWeek = self.l10n.firstDayOfWeek;
     let weekdays = [...self.l10n.weekdays.shorthand];
 


### PR DESCRIPTION
When using flatpickr in time-only mode and refresh the locale the `updateWeekdays` gets triggered and dies in a
```
TypeError: Cannot read property 'children' of undefined
    at updateWeekdays (flatpickr.js:1345)
```