### PR TITLE
add yearFirst option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1028,8 +1028,13 @@ function FlatpickrInstance(
       "div",
       "flatpickr-current-month"
     );
-    currentMonth.appendChild(monthElement);
-    currentMonth.appendChild(yearInput);
+    if (self.config.yearFirst) {
+      currentMonth.appendChild(yearInput);
+      currentMonth.appendChild(monthElement);
+    } else {
+      currentMonth.appendChild(monthElement);
+      currentMonth.appendChild(yearInput);
+    }
 
     monthNavFragment.appendChild(currentMonth);
     container.appendChild(monthNavFragment);
@@ -1960,6 +1965,7 @@ function FlatpickrInstance(
       "static",
       "enableSeconds",
       "disableMobile",
+      "yearFirst",
     ];
 
     const userConfig = {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -246,6 +246,9 @@ Use it along with "enableTime" to create a time picker. */
 
   /* See https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements */
   wrap: boolean;
+
+  /* if true, the order in current month navigator is Y m instead of m Y */
+  yearFirst: boolean;
 }
 
 export type Options = Partial<BaseOptions>;
@@ -317,6 +320,7 @@ export interface ParsedOptions {
   time_24hr: boolean;
   weekNumbers: boolean;
   wrap: boolean;
+  yearFirst: boolean;
 }
 
 export const defaults: ParsedOptions = {
@@ -399,4 +403,5 @@ export const defaults: ParsedOptions = {
   time_24hr: false,
   weekNumbers: false,
   wrap: false,
+  yearFirst: false,
 };


### PR DESCRIPTION
Hi,

In some countries the default order format is YMD.  
So, we'd like to show like an attached image.

<img width="389" alt="Screen Shot 2019-10-15 at 22 14 52" src="https://user-images.githubusercontent.com/33728622/66836695-ca54c300-ef9c-11e9-88b8-6a049fb132c8.png">

I added `yearFirst` option.  
If you have any idea of option name, I'd like you guys to feedback about this PR.  

- Related issue: [this issue](https://github.com/flatpickr/flatpickr/issues/1964)
- Inspired this [PR](https://github.com/flatpickr/flatpickr/pull/974)

Thanks.