### PR TITLE
fix: only apply `step` attribute to mobile input when present on main input (closes #1982)

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -860,7 +860,7 @@ describe("flatpickr", () => {
         });
 
         describe("step attribute", () => {
-          it("copy value if setted", () => {
+          it("copy value if present", () => {
             const el = document.createElement("input");
             el.setAttribute("step", "3");
 
@@ -872,7 +872,7 @@ describe("flatpickr", () => {
             expect(mobileInput.getAttribute("step")).toBe("3");
           });
 
-          it("don't set 'any' value if not setted", () => {
+          it("don't set a default value if not present", () => {
             const el = document.createElement("input");
             el.removeAttribute("step");
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -872,7 +872,7 @@ describe("flatpickr", () => {
             expect(mobileInput.getAttribute("step")).toBe("3");
           });
 
-          it("set 'any' value if not setted", () => {
+          it("don't set 'any' value if not setted", () => {
             const el = document.createElement("input");
             el.removeAttribute("step");
 
@@ -881,7 +881,7 @@ describe("flatpickr", () => {
 
             const mobileInput = fp.mobileInput as HTMLInputElement;
 
-            expect(mobileInput.getAttribute("step")).toBe("any");
+            expect(mobileInput.getAttribute("step")).toBe(null);
           });
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2575,7 +2575,6 @@ function FlatpickrInstance(
       "input",
       self.input.className + " flatpickr-mobile"
     );
-    self.mobileInput.step = self.input.getAttribute("step") || "any";
     self.mobileInput.tabIndex = 1;
     self.mobileInput.type = inputType;
     self.mobileInput.disabled = self.input.disabled;
@@ -2601,6 +2600,9 @@ function FlatpickrInstance(
 
     if (self.config.maxDate)
       self.mobileInput.max = self.formatDate(self.config.maxDate, "Y-m-d");
+
+    if (self.input.getAttribute("step"))
+      self.mobileInput.step = String(self.input.getAttribute("step"));
 
     self.input.type = "hidden";
     if (self.altInput !== undefined) self.altInput.type = "hidden";


### PR DESCRIPTION
This PR makes sure to only apply the `step` attribute to the mobile input when it's present on the main input. Setting it always and use `any` as fallback values can cause issues on some mobile devices.

Closes #1982.