### PR TITLE
Fix onKeyDown evt listener not working with the `wrap`config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1597,7 +1597,9 @@ function FlatpickrInstance(
     // "Delete"     (IE "Del")           46
 
     const eventTarget = getEventTarget(e);
-    const isInput = eventTarget === self._input;
+    const isInput = self.config.wrap
+      ? element.contains(eventTarget as HTMLElement)
+      : eventTarget === self._input;
     const allowInput = self.config.allowInput;
     const allowKeydown = self.isOpen && (!allowInput || !isInput);
     const allowInlineKeydown = self.config.inline && isInput && !allowInput;


### PR DESCRIPTION
I have a use case where I don't want to use the flatpickr input, only the calendar. The recommended way of doing so is by using the `wrap` config with a hidden input.

Everything is working fine other than not being able to move the cursor with the arrow keys (left and right). I identified that the `onKeyDown` listener is preventing the default behavior while the calendar is open.

You can check it out in [this sandbox](https://codesandbox.io/s/determined-rain-k6btd). Just type whatever in the inputs or select a date (focus the input again to open the calendar as the bug only happens while it is open), and try to move the cursor left and right.

The change in this PR fixes it.

Thanks for your work on this library! Let me know if I missed anything.