### PR TITLE
Added an option to hide previous and next month days

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -832,13 +832,22 @@ function FlatpickrInstance(
     const firstOfMonth =
       (new Date(year, month, 1).getDay() - self.l10n.firstDayOfWeek + 7) % 7;
 
-    const prevMonthDays = self.utils.getDaysInMonth((month - 1 + 12) % 12, year);
+    const prevMonthDays = self.utils.getDaysInMonth(
+      (month - 1 + 12) % 12,
+      year
+    );
 
     const daysInMonth = self.utils.getDaysInMonth(month, year),
       days = window.document.createDocumentFragment(),
       isMultiMonth = self.config.showMonths > 1,
-      prevMonthDayClass = isMultiMonth ? "prevMonthDay hidden" : "prevMonthDay",
-      nextMonthDayClass = isMultiMonth ? "nextMonthDay hidden" : "nextMonthDay";
+      prevMonthDayClass =
+        isMultiMonth || self.config.hidePrevMonthDays
+          ? "prevMonthDay hidden"
+          : "prevMonthDay",
+      nextMonthDayClass =
+        isMultiMonth || self.config.hideNextMonthDays
+          ? "nextMonthDay hidden"
+          : "nextMonthDay";
 
     let dayNumber = prevMonthDays + 1 - firstOfMonth,
       dayIndex = 0;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -131,6 +131,12 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   /* If "weekNumbers" are enabled, this is the function that outputs the week number for a given dates, optionally along with other text  */
   getWeek: (date: Date) => string | number;
 
+  /* Hides days from next month used to fill the calendar container */
+  hideNextMonthDays: boolean;
+
+  /* Hides days from prev month used to fill the calendar container */
+  hidePrevMonthDays: boolean;
+
   /*   Adjusts the step for the hour input (incl. scrolling) */
   hourIncrement: number;
 
@@ -280,6 +286,8 @@ export interface ParsedOptions {
   errorHandler: (err: Error) => void;
   formatDate?: Options["formatDate"];
   getWeek: (date: Date) => string | number;
+  hideNextMonthDays: boolean;
+  hidePrevMonthDays: boolean;
   hourIncrement: number;
   ignoredFocusElements: HTMLElement[];
   inline: boolean;
@@ -365,6 +373,8 @@ export const defaults: ParsedOptions = {
       )
     );
   },
+  hideNextMonthDays: false,
+  hidePrevMonthDays: false,
   hourIncrement: 1,
   ignoredFocusElements: [],
   inline: false,


### PR DESCRIPTION
This PR adds the possibility of making `prevMonthDays` and `nextMonthDays` hidden if chosen with the config variables `hideNextMonthDays` and `hidePrevMonthDays`.