### PR TITLE
Added an option to have the year be a span tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -995,30 +995,40 @@ function FlatpickrInstance(
 
       monthElement = self.monthsDropdownContainer;
     }
+    let yearElement;
+    let yearInput;
 
-    const yearInput = createNumberInput("cur-year", { tabindex: "-1" });
+    if (self.config.yearSelectorType === "input") {
+      yearInput = createNumberInput("cur-year", { tabindex: "-1" });
 
-    const yearElement = yearInput.getElementsByTagName(
-      "input"
-    )[0] as HTMLInputElement;
-    yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      yearElement = yearInput.getElementsByTagName(
+        "input"
+      )[0] as HTMLInputElement;
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
 
-    if (self.config.minDate) {
-      yearElement.setAttribute(
-        "min",
-        self.config.minDate.getFullYear().toString()
-      );
-    }
+      if (self.config.minDate) {
+        yearElement.setAttribute(
+          "min",
+          self.config.minDate.getFullYear().toString()
+        );
+      }
 
-    if (self.config.maxDate) {
-      yearElement.setAttribute(
-        "max",
-        self.config.maxDate.getFullYear().toString()
-      );
+      if (self.config.maxDate) {
+        yearElement.setAttribute(
+          "max",
+          self.config.maxDate.getFullYear().toString()
+        );
 
-      yearElement.disabled =
-        !!self.config.minDate &&
-        self.config.minDate.getFullYear() === self.config.maxDate.getFullYear();
+        yearElement.disabled =
+          !!self.config.minDate &&
+          self.config.minDate.getFullYear() ===
+            self.config.maxDate.getFullYear();
+      }
+    } else {
+      yearElement = createElement<HTMLSpanElement>("span", "cur-year numInput");
+      yearElement.textContent = self.currentYear.toString();
+      yearElement.setAttribute("aria-label", self.l10n.yearAriaLabel);
+      yearInput = yearElement;
     }
 
     const currentMonth = createElement<HTMLDivElement>(
@@ -2715,7 +2725,11 @@ function FlatpickrInstance(
         self.monthsDropdownContainer.value = d.getMonth().toString();
       }
 
-      yearElement.value = d.getFullYear().toString();
+      if (self.config.yearSelectorType === "input") {
+        (<HTMLInputElement>yearElement).value = d.getFullYear().toString();
+      } else {
+        yearElement.textContent = d.getFullYear().toString();
+      }
     });
 
     self._hidePrevMonthArrow =
@@ -2775,7 +2789,8 @@ function FlatpickrInstance(
     if (isPrevMonth || isNextMonth) {
       changeMonth(isPrevMonth ? -1 : 1);
     } else if (
-      self.yearElements.indexOf(eventTarget as HTMLInputElement) >= 0
+      self.yearElements.indexOf(eventTarget as HTMLInputElement) >= 0 &&
+      self.config.yearSelectorType === "input"
     ) {
       (eventTarget as HTMLInputElement).select();
     } else if ((eventTarget as Element).classList.contains("arrowUp")) {

--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -334,6 +334,16 @@
     span.arrowDown:after
       border-top-color $monthForeground
 
+  span.cur-year
+    margin-left 0.5ch
+    font-size inherit
+    font-family inherit
+    font-weight 300
+    line-height inherit
+
+    &:hover
+      background: alpha($invertedBg, 0.05)
+
   input.cur-year
     background transparent
     box-sizing border-box

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -30,7 +30,7 @@ export interface Elements {
 
   monthsDropdownContainer: HTMLSelectElement;
 
-  yearElements: HTMLInputElement[];
+  yearElements: (HTMLInputElement | HTMLSpanElement)[];
   monthElements: HTMLSpanElement[];
 
   // month nav getters

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -246,6 +246,9 @@ Use it along with "enableTime" to create a time picker. */
 
   /* See https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements */
   wrap: boolean;
+
+  /* How the year in the calendar should be shown */
+  yearSelectorType: "input" | "static";
 }
 
 export type Options = Partial<BaseOptions>;
@@ -317,6 +320,7 @@ export interface ParsedOptions {
   time_24hr: boolean;
   weekNumbers: boolean;
   wrap: boolean;
+  yearSelectorType: string;
 }
 
 export const defaults: ParsedOptions = {
@@ -399,4 +403,5 @@ export const defaults: ParsedOptions = {
   time_24hr: false,
   weekNumbers: false,
   wrap: false,
+  yearSelectorType: "input",
 };


### PR DESCRIPTION
Some times we don't want the year input be an actual input for the header. This PR makes it possible to have the year indicator on the header be a `span` like we're able to do with the month selector.