### PR TITLE
Add aria-label to months

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -982,6 +982,9 @@ function FlatpickrInstance(
         "flatpickr-monthDropdown-months"
       );
 
+      self.monthsDropdownContainer.setAttribute("aria-label", self.l10n.monthAriaLabel);
+
+
       bind(self.monthsDropdownContainer, "change", (e: Event) => {
         const target = getEventTarget(e) as HTMLSelectElement;
         const selectedMonth = parseInt(target.value, 10);

--- a/src/l10n/default.ts
+++ b/src/l10n/default.ts
@@ -65,6 +65,7 @@ export const english: Locale = {
   toggleTitle: "Click to toggle",
   amPM: ["AM", "PM"],
   yearAriaLabel: "Year",
+  monthAriaLabel: "Month",
   hourAriaLabel: "Hour",
   minuteAriaLabel: "Minute",
   time_24hr: false,

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -55,6 +55,7 @@ export type Locale = {
   toggleTitle: string;
   amPM: [string, string];
   yearAriaLabel: string;
+  monthAriaLabel: string;
   hourAriaLabel: string;
   minuteAriaLabel: string;
   time_24hr: boolean;


### PR DESCRIPTION
We are getting errors from the [WebAIM WAVE browser extensions](https://wave.webaim.org/extension/) for a missing label on the months select. Adding an `aria-label` fixes the issue.