### PR TITLE
Fix mobile datepickers when used with a keyboard

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -350,19 +350,30 @@ describe("flatpickr", () => {
   describe("date formatting", () => {
     describe("default formatter", () => {
       const DEFAULT_FORMAT_1 = "d.m.y H:i:S",
-        DEFAULT_FORMAT_2 = "D j F, 'y";
+        DEFAULT_FORMAT_2 = "D j F, 'y",
+        DEFAULT_FORMAT_3 = 'Y-m-d';
 
-      it(`should format the date with the pattern "${DEFAULT_FORMAT_1}"`, () => {
-        const RESULT = "20.10.16 09:19:59";
-        createInstance({
-          dateFormat: DEFAULT_FORMAT_1,
+        it(`should format the date with the pattern "${DEFAULT_FORMAT_1}"`, () => {
+          const RESULT = "20.10.16 09:19:59";
+          createInstance({
+            dateFormat: DEFAULT_FORMAT_1,
+          });
+  
+          fp.setDate("20.10.16 09:19:59");
+          expect(fp.input.value).toEqual(RESULT);
+          fp.setDate("2015.11.21 19:29:49");
+          expect(fp.input.value).not.toEqual(RESULT);
         });
 
-        fp.setDate("20.10.16 09:19:59");
-        expect(fp.input.value).toEqual(RESULT);
-        fp.setDate("2015.11.21 19:29:49");
-        expect(fp.input.value).not.toEqual(RESULT);
-      });
+        it("should format dates for year 0001", () => {
+          const RESULT = "0001-07-15";
+          createInstance({
+            dateFormat: DEFAULT_FORMAT_3,
+          });
+  
+          fp.setDate("0001-07-15");
+          expect(fp.input.value).toEqual(RESULT);
+        });
 
       it(`should format the date with the pattern "${DEFAULT_FORMAT_2}"`, () => {
         const RESULT = "Thu 20 October, '16";

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -12,11 +12,13 @@ import { english } from "../l10n/default";
 export interface FormatterArgs {
   config?: ParsedOptions;
   l10n?: Locale;
+  isMobile?: boolean;
 }
 
 export const createDateFormatter = ({
   config = defaults,
   l10n = english,
+  isMobile = false,
 }: FormatterArgs) => (
   dateObj: Date,
   frmt: string,
@@ -24,7 +26,7 @@ export const createDateFormatter = ({
 ): string => {
   const locale = overrideLocale || l10n;
 
-  if (config.formatDate !== undefined) {
+  if (config.formatDate !== undefined && !isMobile) {
     return config.formatDate(dateObj, frmt, locale);
   }
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -203,8 +203,8 @@ export const formats: Formats = {
     return options.getWeek(date);
   },
 
-  // full year e.g. 2016
-  Y: (date: Date) => date.getFullYear(),
+  // full year e.g. 2016, padded (0001-9999)
+  Y: (date: Date) => pad(date.getFullYear(), 4),
 
   // day in month, padded (01-30)
   d: (date: Date) => pad(date.getDate()),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-export const pad = (number: string | number) => `0${number}`.slice(-2);
+export const pad = (number: string | number, length = 2) => `000${number}`.slice(length * -1);
 export const int = (bool: boolean) => (bool === true ? 1 : 0);
 
 /* istanbul ignore next */


### PR DESCRIPTION
Hey,

The native datepickers when used with a keyboard were failing for intermediate values, like entering only the first character for a year.

These are the fixes.