### PR TITLE
New Duration plugin

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -54,12 +54,6 @@
     var fp = flatpickr(".date", {
       time_24hr: true,
       plugins: [
-      // new monthSelectPlugin({
-      //     shorthand: true, //defaults to false
-      //     dateFormat: "m.y", //defaults to "F Y"
-      //     altFormat: "F Y", //defaults to "F Y"
-      //     theme: "dark" // defaults to "light"
-      //   })
       new durationPlugin({})
     ]
     })

--- a/index.template.html
+++ b/index.template.html
@@ -52,6 +52,7 @@
 
   <script>
     var fp = flatpickr(".date", {
+      time_24hr: true,
       plugins: [
       // new monthSelectPlugin({
       //     shorthand: true, //defaults to false

--- a/index.template.html
+++ b/index.template.html
@@ -46,12 +46,21 @@
   <script src="./dist/plugins/confirmDate/confirmDate.js"></script>
   <script src="./dist/plugins/minMaxTimePlugin.js"></script>
   <script src="./dist/plugins/monthSelect/index.js"></script>
+  <script src="./dist/plugins/duration/index.js"></script>
   <script src="./dist/plugins/scrollPlugin.js"></script>
   <script src="./dist/plugins/weekSelect/weekSelect.js"></script>
 
   <script>
     var fp = flatpickr(".date", {
-
+      plugins: [
+      // new monthSelectPlugin({
+      //     shorthand: true, //defaults to false
+      //     dateFormat: "m.y", //defaults to "F Y"
+      //     altFormat: "F Y", //defaults to "F Y"
+      //     theme: "dark" // defaults to "light"
+      //   })
+      new durationPlugin({})
+    ]
     })
   </script>
 </body>

--- a/index.template.html
+++ b/index.template.html
@@ -52,10 +52,7 @@
 
   <script>
     var fp = flatpickr(".date", {
-      time_24hr: true,
-      plugins: [
-      new durationPlugin({})
-    ]
+      
     })
   </script>
 </body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,8 @@ function FlatpickrInstance(
     if (self.hourElement === undefined || self.minuteElement === undefined)
       return;
 
-    let hours = (parseInt(self.hourElement.value.slice(-2), 10) || 0) % 24,
+    let hoursHalfParsed = (parseInt(self.hourElement.value.slice(-2), 10) || 0);
+    let hours =  self._duration ? hoursHalfParsed : hoursHalfParsed % 24,
       minutes = (parseInt(self.minuteElement.value, 10) || 0) % 60,
       seconds =
         self.secondElement !== undefined
@@ -318,9 +319,9 @@ function FlatpickrInstance(
     if (!self.hourElement || !self.minuteElement || self.isMobile) return;
 
     self.hourElement.value = pad(
-      !self.config.time_24hr
-        ? ((12 + hours) % 12) + 12 * int(hours % 12 === 0)
-        : hours
+      self.config.time_24hr || self._duration
+        ? hours
+        : ((12 + hours) % 12) + 12 * int(hours % 12 === 0)
     );
 
     self.minuteElement.value = pad(minutes);

--- a/src/plugins/duration/index.ts
+++ b/src/plugins/duration/index.ts
@@ -51,6 +51,7 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
     let latestSelectedTime: Time;
     
     return (parent: Instance) => {
+
         parent.config.dateFormat = config.timeFormat;
         parent.config.altFormat = config.altTimeFormat;
         parent.config.defaultHour = config.defaultHour;
@@ -90,13 +91,24 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
         //         .join("");
         // };
 
+        function setup() {
+          parent._duration = true;
+          if (!parent.hourElement || !parent.minuteElement) {
+            console.warn('No hour/minute elements found; plugin will not work');
+            return;
+          }
+          parent.hourElement.setAttribute("max", config.maxHours.toString());
+          parent.hourElement.setAttribute("min", config.minHours.toString()); 
+          
+        }
+
         function setupHoursForDuration() {
             latestSelectedTime = {
               hours: parent.config.defaultHour,
               minutes: parent.config.defaultMinute,
               seconds: parent.config.defaultSeconds
             } as Time;
-        
+        console.log(latestSelectedTime)
             // parent.setHours(
             //   self.latestSelectedTime.hours, 
             //   self.latestSelectedTime.minutes,
@@ -105,7 +117,7 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
           }
 
         function valueUpdated() {
-            console.log('value updated ', latestSelectedTime)
+            console.log('value updated ', parent.hourElement?.value)
         }
 
         return {
@@ -117,6 +129,7 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
             },
             onValueUpdate: valueUpdated,
             onReady: [
+                setup,
                 setupHoursForDuration,
                 () => {
                     parent.loadedPlugins.push("duration");

--- a/src/plugins/duration/index.ts
+++ b/src/plugins/duration/index.ts
@@ -52,6 +52,11 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
     let latestSelectedTime: Time;
     
     return (parent: Instance) => {
+        if (!parent.config.time_24hr){
+          console.warn('Duration plugin will not work without time_24hr set to true');
+          return {};
+        }
+
         parent.config.dateFormat = config.timeFormat;
         parent.config.altFormat = config.altTimeFormat;
         parent.config.defaultHour = config.defaultHour;
@@ -101,7 +106,7 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
           latestSelectedTime = {
             hours: parent.config.defaultHour,
             minutes: parent.config.defaultMinute,
-            seconds: parent.config.defaultSeconds
+            seconds: parent.config.defaultSeconds,
           } as Time;
         }
 
@@ -121,8 +126,7 @@ function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
             onParseConfig() {
               parent.config.mode = "single";
               parent.config.enableTime = true;
-              parent.config.noCalendar = true
-              parent.config.time_24hr = true
+              parent.config.noCalendar = true;
             },
             onValueUpdate: valueUpdated,
             onReady: [

--- a/src/plugins/duration/index.ts
+++ b/src/plugins/duration/index.ts
@@ -1,0 +1,129 @@
+import { Instance, Formatting } from "../../types/instance";
+import { Plugin } from "../../types/options";
+
+export type timeToken =
+  | "H"
+  | "S"
+  | "I"
+  | "h"
+  | "i"
+  | "s";
+
+export type TimeFormats = Record<
+  timeToken,
+  (time: Time) => string | number
+>;
+
+export interface Time {
+    hours: number;
+    minutes: number;
+    seconds: number;
+  };
+
+export interface DurationConfig {
+    defaultHour: number;
+    defaultMinute: number;
+    defaultSeconds: number;
+    enableSeconds: boolean;
+    timeFormat: string;
+    altTimeFormat: string;
+    maxHours: number;
+    minHours: number;
+}
+
+export interface DurationFromatting extends Formatting {
+    timeFormats: TimeFormats;
+}
+
+const defaultDurationConfig: DurationConfig = {
+    defaultHour: 8,
+    defaultMinute: 0,
+    defaultSeconds: 0,
+    enableSeconds: false,
+    timeFormat: "H:i",
+    altTimeFormat: "H:i",
+    maxHours: 99,
+    minHours: 0,
+};
+
+function duration(pluginConfig?: Partial<DurationConfig>): Plugin {
+    const config = { ...defaultDurationConfig, ...pluginConfig };
+    let latestSelectedTime: Time;
+    
+    return (parent: Instance) => {
+        parent.config.dateFormat = config.timeFormat;
+        parent.config.altFormat = config.altTimeFormat;
+        parent.config.defaultHour = config.defaultHour;
+        parent.config.defaultMinute = config.defaultMinute;
+        parent.config.defaultSeconds = config.defaultSeconds;
+
+        // const timeFormats: TimeFormats = {
+        //     // hours with leading zero e.g. 03
+        //     H: (time: Time) => parent.pad(time.hours),
+          
+        //     // seconds 00-59
+        //     S: (time: Time) => parent.pad(time.seconds),
+            
+        //     // minutes, padded with leading zero e.g. 09
+        //     I: (time: Time) => parent.pad(time.minutes),
+            
+        //     // hours 0-59
+        //     h: (time: Time) => time.hours,
+
+        //     // minutes 0-59
+        //     i: (time: Time) => time.minutes,
+          
+        //     // seconds 0-59
+        //     s: (time: Time) => time.seconds,
+        //   };
+
+        // function formatTime (): string {
+        //     return parent.config.dateFormat
+        //         .split("")
+        //         .map((c, i, arr) =>
+        //         timeFormats[c as timeToken] && arr[i - 1] !== "\\"
+        //             ? timeFormats[c as timeToken](latestSelectedTime)
+        //             : c !== "\\"
+        //             ? c
+        //             : ""
+        //         )
+        //         .join("");
+        // };
+
+        function setupHoursForDuration() {
+            latestSelectedTime = {
+              hours: parent.config.defaultHour,
+              minutes: parent.config.defaultMinute,
+              seconds: parent.config.defaultSeconds
+            } as Time;
+        
+            // parent.setHours(
+            //   self.latestSelectedTime.hours, 
+            //   self.latestSelectedTime.minutes,
+            //   self.latestSelectedTime.seconds
+            //   );
+          }
+
+        function valueUpdated() {
+            console.log('value updated ', latestSelectedTime)
+        }
+
+        return {
+            onParseConfig() {
+              parent.config.mode = "single";
+              parent.config.enableTime = true;
+              parent.config.noCalendar = true
+              parent.config.time_24hr = true
+            },
+            onValueUpdate: valueUpdated,
+            onReady: [
+                setupHoursForDuration,
+                () => {
+                    parent.loadedPlugins.push("duration");
+                },
+            ]
+          };
+    };
+}  
+
+export default duration;

--- a/src/plugins/duration/tests.spec.ts
+++ b/src/plugins/duration/tests.spec.ts
@@ -1,0 +1,130 @@
+import flatpickr from "../../index";
+import duration from "./index";
+import { Instance } from "types/instance";
+import { Options } from "types/options";
+
+flatpickr.defaultConfig.animate = false;
+
+jest.useFakeTimers();
+
+const createInstance = (config?: Options): Instance => {
+  return flatpickr(
+    document.createElement("input"),
+    config as Options
+  ) as Instance;
+};
+
+function simulate(
+  eventType: string,
+  onElement: Node,
+  options?: object,
+  type?: any
+) {
+  const eventOptions = Object.assign(options || {}, { bubbles: true });
+  const evt = new (type || CustomEvent)(eventType, eventOptions);
+  try {
+    Object.assign(evt, eventOptions);
+  } catch (e) {}
+
+  onElement.dispatchEvent(evt);
+}
+
+describe("duration", () => {
+  it("should set noCalendar and enableTime to true", () => {
+    const fp = createInstance({
+      defaultDate: new Date("2019-04-20"),
+      time_24hr: true,
+      plugins: [duration({})],
+    }) as Instance;
+
+    expect(fp.config.noCalendar).toBeTruthy;
+    expect(fp.config.enableTime).toBeTruthy;
+    expect(fp.hourElement).toBeDefined;
+  });
+
+  it("should set the input to the given defaultHour", () => {
+    const fp = createInstance({
+      time_24hr: true,
+      plugins: [duration({
+        defaultHour: 7
+      })],
+    }) as Instance;
+
+    simulate(
+      "blur",
+      fp.hourElement as Node,
+      { bubbles: true },
+      CustomEvent
+    );
+
+    expect(fp.input.value).toEqual("07:00");
+  });
+
+  it("should set the default input to the given format", () => {
+    const fp = createInstance({
+      time_24hr: true,
+      plugins: [duration({
+        defaultHour: 8,
+        defaultMinute: 0,
+        timeFormat: "H,i"
+      })],
+    }) as Instance;
+
+    simulate(
+      "blur",
+      fp.hourElement as Node,
+      { bubbles: true },
+      CustomEvent
+    );
+
+    expect(fp.input.value).toEqual("08,0");
+  });
+
+  it("should set the input to the given defaultHour and defaultMinute", () => {
+    const fp = createInstance({
+      time_24hr: true,
+      plugins: [duration({})],
+    }) as Instance;
+
+    simulate(
+      "blur",
+      fp.hourElement as Node,
+      { bubbles: true },
+      CustomEvent
+    );
+
+    if(fp.hourElement)
+      fp.hourElement.value = "34";
+
+      simulate(
+        "blur",
+        fp.hourElement as Node,
+        { bubbles: true },
+        CustomEvent
+      );
+
+    expect(fp.input.value).toEqual("34:00");
+  });
+
+  it("should set the input to the given defaultSeconds", () => {
+    const fp = createInstance({
+      time_24hr: true,
+      plugins: [duration({
+        defaultHour: 8,
+        defaultMinute: 0,
+        enableSeconds: true,
+        timeFormat: "H:I:S",
+        defaultSeconds: 24
+      })],
+    }) as Instance;
+
+    simulate(
+      "blur",
+      fp.hourElement as Node,
+      { bubbles: true },
+      CustomEvent
+    );
+
+    expect(fp.input.value).toEqual("08:00:24");
+  });
+});

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -143,7 +143,8 @@ export type Instance = Elements &
     __hideNextMonthArrow: boolean;
     __hidePrevMonthArrow: boolean;
     _positionCalendar: (customPositionElement?: HTMLElement) => void;
-
+    _duration: boolean;
+    
     utils: {
       getDaysInMonth: (month?: number, year?: number) => number;
     };


### PR DESCRIPTION
I propose a new "Duration" plugin. It allows users to introduce a duration (hours, minutes and optionally seconds) without the 24 hours limit. 
I had to make some small changes in source code to bypass standard hours formatting, francly I couldn't find a way to write it out. The tests pass however