### PR TITLE
Add Lit Flatpickr to the "See also" -section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ See also:
 * [Stimulus.js Controller](https://github.com/adrienpoly/stimulus-flatpickr)
 * [Svelte Component](https://github.com/jacobmischka/svelte-flatpickr)
 * [vue-flatpickr component](https://github.com/ankurk91/vue-flatpickr-component)
+* [lit-flatpickr component](https://github.com/Matsuuu/lit-flatpickr)
 
 ## Supporting flatpickr
 


### PR DESCRIPTION
I created a Lit Element wrapper for Flatpickr, and am planning to optimize it as time goes by.

Added it to the see also part with other implementations