### PR TITLE
support function for `position` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2123,6 +2123,9 @@ function FlatpickrInstance(
   }
 
   function positionCalendar(customPositionElement?: HTMLElement) {
+    if (typeof self.config.position === "function") {
+      return void self.config.position(self, customPositionElement);
+    }
     if (self.calendarContainer === undefined) return;
 
     triggerEvent("onPreCalendarPosition");


### PR DESCRIPTION
We needed the support a case where neither positioning the datepicker above or below the input works.

With this you can send in a function in the `position` option and do the positioning that way.

This is what our positioning function looks like (in an ember component):

```js
import { createPopper } from '@popperjs/core';

// the rest of the component here :)

handlePosition(flatPickrInstance) {
    if (!this.popperInstance) {
      const arrowElement = document.createElement('div');
      arrowElement.classList.add('datetime-picker__arrow');
      flatPickrInstance.calendarContainer.appendChild(arrowElement);
      this.popperInstance = createPopper(
        flatPickrInstance.element,
        flatPickrInstance.calendarContainer,
        {
          placement: 'bottom',
          strategy: 'fixed',
          modifiers: [
            {
              name: 'arrow',
              options: {
                element: arrowElement,
              },
            },
            {
              name: 'flip',
              options: {
                fallbackPlacements: ['top', 'left'],
              },
            },
            {
              name: 'offset',
              options: {
                offset: () => {
                  return [0, 10];
                },
              },
            },
          ],
        }
      );
    } else {
      this.popperInstance.forceUpdate();
    }
  }
```

Another option is to make flatpickr use `@popperjs/core` for positioning when its `auto` ?

Anyway with this you can send add your own logic and it solved our problem :)