### PR TITLE
monthSelect plugin fixes

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -144,6 +144,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         }
         fp.currentYear = selectedDate.getFullYear();
         fp.currentYearElement.value = String(fp.currentYear);
+        fp.currentMonth = selectedDate.getMonth();
       }
       if (fp.rContainer) {
         const months: NodeListOf<ElementDate> = fp.rContainer.querySelectorAll(

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -54,7 +54,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
           ?.querySelector<ElementDate>(".flatpickr-monthSelect-month.selected")!
           .dateObj.getMonth();
 
-        if (selectedMonth === 1) {
+        if (selectedMonth === 0) {
           fp.currentYear--;
         }
         selectYear();
@@ -68,7 +68,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
           ?.querySelector<ElementDate>(".flatpickr-monthSelect-month.selected")!
           .dateObj.getMonth();
 
-        if (selectedMonth === 12) {
+        if (selectedMonth === 11) {
           fp.currentYear++;
         }
         selectYear();


### PR DESCRIPTION
Noticed some bugs while using the plugin:
- The left arrow only works when February is selected; the right arrow doesn't work
- With dates less than a year in the past disabled, using the left arrow selects a month outside the allowed range

This PR fixes the above issues, but arrow navigation is still broken in that you have to have January/December selected in order to move to the previous/next year.