### PR TITLE
fix #2157 - Dom Util getEventTarget sometime throws illegal invocation

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -68,11 +68,13 @@ export function createNumberInput(
 }
 
 export function getEventTarget(event: Event): EventTarget | null {
-  if (typeof event.composedPath === "function") {
-    const path = event.composedPath();
-
-    return path[0];
+  try {
+    if (typeof event.composedPath === "function") {
+      const path = event.composedPath();
+      return path[0];
+    }
+    return event.target;
+  } catch (error) {
+    return event.target;
   }
-
-  return event.target;
 }


### PR DESCRIPTION
- in some cases (might depend on Framework used, in our case it's SalesForce), it can throw an `illegal invocation` error and if that is the case then catching the error and defaulting to `return event.target` is what works. This PR wraps the code in a try/catch and if an error is caught then will default to `return event.target`
- fixes #2157