### PR TITLE
Support right alignment with arrow styles - fixes #1849

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1456,7 +1456,7 @@ function FlatpickrInstance(
         if (
           self.timeContainer !== undefined &&
           self.minuteElement !== undefined &&
-          self.hourElement !== undefined && 
+          self.hourElement !== undefined &&
           self.input.value !== "" &&
           self.input.value !== undefined
         ) {
@@ -2169,12 +2169,22 @@ function FlatpickrInstance(
 
     if (self.config.inline) return;
 
-    const left =
-      window.pageXOffset +
-      inputBounds.left -
-      (configPosHorizontal != null && configPosHorizontal === "center"
-        ? (calendarWidth - inputBounds.width) / 2
-        : 0);
+    let left = window.pageXOffset + inputBounds.left;
+    let isCenter = false;
+    let isRight = false;
+
+    if (configPosHorizontal === "center") {
+      left -= (calendarWidth - inputBounds.width) / 2;
+      isCenter = true;
+    } else if (configPosHorizontal === "right") {
+      left -= calendarWidth - inputBounds.width;
+      isRight = true;
+    }
+
+    toggleClass(self.calendarContainer, "arrowLeft", !isCenter && !isRight);
+    toggleClass(self.calendarContainer, "arrowCenter", isCenter);
+    toggleClass(self.calendarContainer, "arrowRight", isRight);
+
     const right =
       window.document.body.offsetWidth -
       (window.pageXOffset + inputBounds.right);

--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -112,10 +112,15 @@
     width 0
     left 22px
 
-  &.rightMost
+  &.rightMost, &.arrowRight
     &:before, &:after
       left auto
       right 22px
+
+  &.arrowCenter
+    &:before, &:after
+      left 50%
+      right 50%
 
   &:before
     border-width 5px


### PR DESCRIPTION
Extends `position` option to justify right. Includes fixes for moving the arrow as well.
Extends and fixes issue #1849 
<img width="347" alt="Screen Shot 2020-07-06 at 11 40 45 AM" src="https://user-images.githubusercontent.com/3029679/86627895-e1e63880-bf7d-11ea-970f-fb3b50092bbf.png">
<img width="355" alt="Screen Shot 2020-07-06 at 11 40 27 AM" src="https://user-images.githubusercontent.com/3029679/86627910-e7438300-bf7d-11ea-8c78-1ed5acd08408.png">
<img width="353" alt="Screen Shot 2020-07-06 at 11 39 50 AM" src="https://user-images.githubusercontent.com/3029679/86627913-e9a5dd00-bf7d-11ea-8c39-4a620b375fd6.png">

Will update documentation as well