### PR TITLE
update homepage url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "bugs": {
     "url": "https://github.com/chmln/flatpickr/issues"
   },
-  "homepage": "https://chmln.github.io/flatpickr",
+  "homepage": "https://flatpickr.js.org",
   "keywords": [
     "javascript",
     "datetimepicker",


### PR DESCRIPTION
https://chmln.github.io/flatpickr redirects to https://flatpickr.js.org so it should be used as homepage url to prevent unnecessary redirect.