### PR TITLE
Use native mobile input when 'inline: true' is set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2061,7 +2061,6 @@ function FlatpickrInstance(
 
     self.isMobile =
       !self.config.disableMobile &&
-      !self.config.inline &&
       self.config.mode === "single" &&
       !self.config.disable.length &&
       !self.config.enable.length &&


### PR DESCRIPTION
Setting 'disableMobile: true' will override this behavior.