### PR TITLE
Correctly align prev-month/next-month arrows

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -224,6 +224,7 @@
     svg
       width 14px
       height 14px
+      vertical-align top
 
       path
         transition fill 0.1s


### PR DESCRIPTION
Fixes misaligned arrows compared to month and year:
![image](https://user-images.githubusercontent.com/8647429/89106484-813a0680-d42a-11ea-941e-d7bf77538747.png)
