### PR TITLE
fix: Focus calendar day on open()/toggle()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1899,9 +1899,10 @@ function FlatpickrInstance(
       positionCalendar(positionElement);
     }
 
-    if (self.config.enableTime === true && self.config.noCalendar === true) {
-      if (
-        self.config.allowInput === false &&
+    if(self.config.noCalendar === false) {
+      focusOnDay(undefined, 7);
+    } else if (self.config.enableTime === true && self.config.noCalendar === true) {
+      if ((self.config.allowInput === false || self.config.wrap) &&
         (e === undefined ||
           !(self.timeContainer as HTMLDivElement).contains(
             e.relatedTarget as Node


### PR DESCRIPTION
Added a call to `focusOnDay()` inside `open()` so that triggering the datepicker to open via keyboard focuses the calendar days when days are visible.  This allows keyboard controls to then navigate around the calendar days rather than going straight to the "hours" field.

Included is a change that causes datepickers that only have a time picker available but are using the `wrap: true` option to focus on the "hours" field whenever the time picker is opened via keyboard interaction on the `data-toggle` element.