### PR TITLE
Make clearing on backspace configurable

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -659,6 +659,54 @@ describe("flatpickr", () => {
       expect(fp._input.value).toBe("");
     });
 
+    it("onKeyDown defaults to true", () => {
+      createInstance({});
+
+      expect(fp.config.allowClearing).toBe(true);
+    });
+
+    it("onKeyDown backspace while allowClearing is true", () => {
+      createInstance({
+        allowClearing: true,
+      });
+
+      fp.setDate("2016-11-03");
+      fp.open();
+
+      simulate(
+        "keydown",
+        fp.input,
+        {
+          keyCode: 8, // "Backspace"
+          bubbles: true,
+        },
+        KeyboardEvent
+      );
+
+      expect(fp.selectedDates.length).toBe(0);
+    });
+
+    it("onKeyDown backspace while allowClearing is false", () => {
+      createInstance({
+        allowClearing: false,
+      });
+
+      fp.setDate("2016-11-03");
+      fp.open();
+
+      simulate(
+        "keydown",
+        fp.input,
+        {
+          keyCode: 8, // "Backspace"
+          bubbles: true,
+        },
+        KeyboardEvent
+      );
+
+      expect(fp.selectedDates.length).toBe(1);
+    });
+
     it("onKeyDown", () => {
       createInstance({
         enableTime: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1665,7 +1665,7 @@ function FlatpickrInstance(
 
         case 8:
         case 46:
-          if (isInput && !self.config.allowInput) {
+          if (isInput && !allowInput && self.config.allowClearing) {
             e.preventDefault();
             self.clear();
           }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -48,6 +48,11 @@ export type Plugin<E = {}> = (fp: Instance & E) => Options;
 
 export interface BaseOptions {
   /*
+  Allows the user to clear the active field by pressing backspace or delete. By default, clearing is enabled.
+  */
+  allowClearing: boolean;
+
+  /*
   Allows the user to enter a date directly input the input field. By default, direct entry is disabled.
   */
   allowInput: boolean;
@@ -264,6 +269,7 @@ export interface ParsedOptions {
   _maxTime?: Date;
   _minDate?: Date;
   _minTime?: Date;
+  allowClearing: boolean;
   allowInput: boolean;
   allowInvalidPreload: boolean;
   altFormat: string;
@@ -331,6 +337,7 @@ export interface ParsedOptions {
 export const defaults: ParsedOptions = {
   _disable: [],
   _enable: [],
+  allowClearing: true,
   allowInput: false,
   allowInvalidPreload: false,
   altFormat: "F j, Y",


### PR DESCRIPTION
In #936 a feature was introduced to make it so that pressing backspace or
delete would clear the input.

For some inputs though, it's desirable to not allow the user to clear
the input. For example, we might want to be able to set a date on load
and only allow modifying that date.

This commit introduces a configuration flag to disable the clearing
feature called `allowClearing`. The field is defaulted to `true` to
preserve the current default behavior.

While I was in here I also added the missing tests for the original behavior,
and the new configuration flag.

Closes #1867