### PR TITLE
Fix bug/change behaviour of arrow navigation in monthSelect plugin

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -3,6 +3,7 @@ import { Russian } from "../l10n/ru";
 import { Instance, DayElement } from "../types/instance";
 import { Options, DateRangeLimit } from "../types/options";
 import confirmDatePlugin from "../plugins/confirmDate/confirmDate";
+import { clickOn, simulate } from "../utils/test_helpers";
 
 flatpickr.defaultConfig.animate = false;
 flatpickr.defaultConfig.closeOnSelect = true;
@@ -70,26 +71,6 @@ function incrementTime(
         MouseEvent
       );
 }
-
-function simulate(
-  eventType: string,
-  onElement: Node,
-  options?: object,
-  type?: any
-) {
-  const eventOptions = Object.assign(options || {}, { bubbles: true });
-  const evt = new (type || CustomEvent)(eventType, eventOptions);
-  try {
-    Object.assign(evt, eventOptions);
-  } catch (e) {}
-
-  onElement.dispatchEvent(evt);
-}
-
-// simulate click
-const clickOn = (element: Node) => {
-  simulate("click", element, { which: 1 }, CustomEvent);
-};
 
 describe("flatpickr", () => {
   beforeEach(beforeEachTest);

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -50,13 +50,8 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         e.preventDefault();
         e.stopPropagation();
 
-        const selectedMonth = fp.rContainer
-          ?.querySelector<ElementDate>(".flatpickr-monthSelect-month.selected")!
-          .dateObj.getMonth();
-
-        if (selectedMonth === 0) {
-          fp.currentYear--;
-        }
+        fp.currentYear--;
+        
         selectYear();
       });
 
@@ -64,13 +59,8 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         e.preventDefault();
         e.stopPropagation();
 
-        const selectedMonth = fp.rContainer
-          ?.querySelector<ElementDate>(".flatpickr-monthSelect-month.selected")!
-          .dateObj.getMonth();
-
-        if (selectedMonth === 11) {
-          fp.currentYear++;
-        }
+        fp.currentYear++;
+        
         selectYear();
       });
     }
@@ -133,19 +123,22 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
 
     function selectYear() {
       let selectedDate = fp.selectedDates[0];
-      if (selectedDate) {
-        selectedDate = new Date(selectedDate);
-        selectedDate.setFullYear(fp.currentYear);
-        if (fp.config.minDate && selectedDate < fp.config.minDate) {
-          selectedDate = fp.config.minDate;
-        }
-        if (fp.config.maxDate && selectedDate > fp.config.maxDate) {
-          selectedDate = fp.config.maxDate;
-        }
-        fp.currentYear = selectedDate.getFullYear();
-        fp.currentYearElement.value = String(fp.currentYear);
-        fp.currentMonth = selectedDate.getMonth();
+      
+      selectedDate = selectedDate 
+          ? new Date(selectedDate)
+          : new Date;
+      
+      selectedDate.setFullYear(fp.currentYear);
+      if (fp.config.minDate && selectedDate < fp.config.minDate) {
+        selectedDate = fp.config.minDate;
       }
+      if (fp.config.maxDate && selectedDate > fp.config.maxDate) {
+        selectedDate = fp.config.maxDate;
+      }
+      fp.currentYear = selectedDate.getFullYear();
+      fp.currentYearElement.value = String(fp.currentYear);
+      fp.currentMonth = selectedDate.getMonth();
+
       if (fp.rContainer) {
         const months: NodeListOf<ElementDate> = fp.rContainer.querySelectorAll(
           ".flatpickr-monthSelect-month"

--- a/src/plugins/monthSelect/tests.spec.ts
+++ b/src/plugins/monthSelect/tests.spec.ts
@@ -3,6 +3,7 @@ import monthSelectPlugin from "./index";
 import { German } from "l10n/de";
 import { Instance } from "types/instance";
 import { Options } from "types/options";
+import { clickOn } from '../../utils/test_helpers'
 
 flatpickr.defaultConfig.animate = false;
 
@@ -59,4 +60,86 @@ describe("monthSelect", () => {
 
     expect(fp.altInput.value).toEqual("03 19");
   });
+
+  describe ("using the nav arrows", () => {
+    it ("navigates to next year if no month is selected", () => {
+      const fp = createInstance({
+        plugins: [monthSelectPlugin({})],
+      }) as Instance;
+      
+      const now = new Date;
+      const currentYear = now.getFullYear()
+      const currentMonth = now.getMonth()
+      
+      expect(fp.currentYear).toEqual(currentYear)
+      expect(fp.currentMonth).toEqual(currentMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(currentYear));
+      
+      clickOn(fp['nextMonthNav'])
+
+      expect(fp.currentYear).toEqual(currentYear + 1)
+      expect(fp.currentMonth).toEqual(currentMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(currentYear + 1));
+    })
+
+    it ("navigates to previous year if no month is selected", () => {
+      const fp = createInstance({
+        plugins: [monthSelectPlugin({})],
+      }) as Instance;
+      
+      const now = new Date;
+      const currentYear = now.getFullYear()
+      const currentMonth = now.getMonth()
+      
+      expect(fp.currentYear).toEqual(currentYear)
+      expect(fp.currentMonth).toEqual(currentMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(currentYear));
+
+      clickOn(fp['prevMonthNav'])
+
+      expect(fp.currentYear).toEqual(currentYear - 1)
+      expect(fp.currentMonth).toEqual(currentMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(currentYear - 1));
+    })
+
+    it ("navigates to next year if month is already selected", () => {
+      const fp = createInstance({
+        defaultDate: new Date("2016-09-13"),
+        plugins: [monthSelectPlugin({})],
+      }) as Instance;
+      
+      const defaultYear = 2016
+      const defaultMonth = 9 - 1;
+      
+      expect(fp.currentYear).toEqual(defaultYear)
+      expect(fp.currentMonth).toEqual(defaultMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(defaultYear));
+
+      clickOn(fp['nextMonthNav'])
+
+      expect(fp.currentYear).toEqual(defaultYear + 1)
+      expect(fp.currentMonth).toEqual(defaultMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(defaultYear + 1));
+    })
+
+    it ("navigates to previous year if month is already selected", () => {
+      const fp = createInstance({
+        defaultDate: new Date("2016-09-13"),
+        plugins: [monthSelectPlugin({})],
+      }) as Instance;
+      
+      const defaultYear = 2016
+      const defaultMonth = 9 - 1;
+      
+      expect(fp.currentYear).toEqual(defaultYear)
+      expect(fp.currentMonth).toEqual(defaultMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(defaultYear));
+
+      clickOn(fp['prevMonthNav'])
+
+      expect(fp.currentYear).toEqual(defaultYear - 1)
+      expect(fp.currentMonth).toEqual(defaultMonth)
+      expect(fp['yearElements'][0].value).toEqual(String(defaultYear - 1));
+    })
+  })
 });

--- a/src/utils/test_helpers.ts
+++ b/src/utils/test_helpers.ts
@@ -1,0 +1,21 @@
+let simulate = (
+  eventType: string,
+  onElement: Node,
+  options?: object,
+  type?: any
+)  => {
+  const eventOptions = Object.assign(options || {}, { bubbles: true });
+  const evt = new (type || CustomEvent)(eventType, eventOptions);
+  try {
+    Object.assign(evt, eventOptions);
+  } catch (e) {}
+
+  onElement.dispatchEvent(evt);
+};
+
+// simulate click
+let clickOn = (element: Node) => {
+  simulate("click", element, { which: 1 }, CustomEvent);
+};
+
+export {clickOn, simulate}


### PR DESCRIPTION
See: https://github.com/flatpickr/flatpickr/issues/2271

Hi,
The monthSelect plugin has a bug or, at least, a very counter intuitive behaviour.

Current Behaviour: the users can navigate to the previous year only if January is selected; the users can navigate to the next year only if December is selected. If the users select any other month (February, March, ...), they are unable to use the arrows to navigate years.

Expected Behaviour: the year should be decreased/increased when the user clicks on the Previous/Next buttons, no matter what month I selected.

This pull request implements the new behaviour, also backing it up and documenting it in the unit tests, describing each scenario.

PS: to prevent duplication, clickOn and simulate helper functions were also moved from src/__tests__/index.spec.ts to a new  src/utils/test_helpers.ts