### PR TITLE
Fix stale year display in monthSelect plugin

### DIFF
--- a/__tests__/src/plugins/monthSelect/index.spec.ts
+++ b/__tests__/src/plugins/monthSelect/index.spec.ts
@@ -80,6 +80,25 @@ describe("monthSelect", () => {
 
         expect(fp.currentYear).toEqual(initYear);
       });
+
+      it("should update displayed year when clicked (#2277)", () => {
+        const initYear = new Date().getFullYear();
+
+        const fp = createInstance({
+          plugins: [monthSelectPlugin()],
+        }) as Instance;
+
+        const prevButton = fp.monthNav.querySelector(".flatpickr-prev-month")!;
+        prevButton.dispatchEvent(new MouseEvent("click"));
+
+        expect(fp.currentYearElement.value).toEqual(`${initYear - 1}`);
+
+        const nextButton = fp.monthNav.querySelector(".flatpickr-next-month")!;
+        nextButton.dispatchEvent(new MouseEvent("click"));
+        nextButton.dispatchEvent(new MouseEvent("click"));
+
+        expect(fp.currentYearElement.value).toEqual(`${initYear + 1}`);
+      });
     });
   });
 });

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -131,9 +131,11 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
           selectedDate = fp.config.maxDate;
         }
         fp.currentYear = selectedDate.getFullYear();
-        fp.currentYearElement.value = String(fp.currentYear);
         fp.currentMonth = selectedDate.getMonth();
       }
+
+      fp.currentYearElement.value = String(fp.currentYear);
+
       if (fp.rContainer) {
         const months: NodeListOf<ElementDate> = fp.rContainer.querySelectorAll(
           ".flatpickr-monthSelect-month"


### PR DESCRIPTION
Fixes #2277.

Originally, in the monthSelect plugin,
clicking on the prev/next year buttons
failed to update the year shown at the top of the calendar
until after the user made an initial selection.
Under the hood, clicking the prev/next year buttons did change the year,
meaning that the selected month/year would not necessarily match
the month/year displayed in the UI.

This occurred because the line that updates the view
was hidden behind an `if` clause that it shouldn't have been.
This commit moves that line to the appropriate place.