### PR TITLE
Fix monthSelect's .today/.selected styling

### DIFF
--- a/__tests__/src/plugins/monthSelect/index.spec.ts
+++ b/__tests__/src/plugins/monthSelect/index.spec.ts
@@ -123,4 +123,55 @@ describe("monthSelect", () => {
       });
     });
   });
+
+  describe("month cell styling", () => {
+    it("should apply .today to current month of current year", () => {
+      const fp = createInstance({
+        plugins: [monthSelectPlugin()],
+      }) as Instance;
+
+      const getTodayCell = (): (Element | null | undefined) =>
+        fp.rContainer?.querySelector(".today");
+      const currentMonth = fp.l10n.months.longhand[new Date().getMonth()]
+
+      expect(getTodayCell()?.textContent).toEqual(currentMonth);
+
+      const prevButton = fp.monthNav.querySelector(".flatpickr-prev-month")!;
+      prevButton.dispatchEvent(new MouseEvent("click"));
+
+      expect(getTodayCell()).toBeNull();
+
+      const nextButton = fp.monthNav.querySelector(".flatpickr-next-month")!;
+      nextButton.dispatchEvent(new MouseEvent("click"));
+
+      expect(getTodayCell()?.textContent).toEqual(currentMonth);
+    });
+
+    it("should apply .selected to selected month of selected year", () => {
+      const fp = createInstance({
+        plugins: [monthSelectPlugin()],
+      }) as Instance;
+
+      const getSelectedCell = (): (Element | null | undefined) =>
+        fp.rContainer?.querySelector(".selected");
+
+      expect(getSelectedCell()).toBeNull();
+
+      const selectionTarget = fp.rContainer!
+        .querySelector(".flatpickr-monthSelect-month:nth-child(6)")!;
+      selectionTarget.dispatchEvent(new MouseEvent("click"));
+
+      expect(getSelectedCell()?.textContent).toEqual("June");
+
+      const prevButton = fp.monthNav.querySelector(".flatpickr-prev-month")!;
+      prevButton.dispatchEvent(new MouseEvent("click"));
+
+      expect(getSelectedCell()).toBeNull();
+
+      const nextButton = fp.monthNav.querySelector(".flatpickr-next-month")!;
+      nextButton.dispatchEvent(new MouseEvent("click"));
+
+      expect(getSelectedCell()?.textContent).toEqual("June");
+    });
+  });
 });

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "../../types/options";
 import { Instance } from "../../types/instance";
 import { monthToStr } from "../../utils/formatting";
-import { getEventTarget } from "../../utils/dom";
+import { clearNode, getEventTarget } from "../../utils/dom";
 
 export interface Config {
   shorthand: boolean;
@@ -32,10 +32,9 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     const self = { monthsContainer: null as null | HTMLDivElement };
 
     function clearUnnecessaryDOMElements(): void {
-      if (!fp.rContainer || !fp.daysContainer || !fp.weekdayContainer) return;
+      if (!fp.rContainer) return;
 
-      fp.rContainer.removeChild(fp.daysContainer);
-      fp.rContainer.removeChild(fp.weekdayContainer);
+      clearNode(fp.rContainer);
 
       for (let index = 0; index < fp.monthElements.length; index++) {
         const element = fp.monthElements[index];
@@ -45,25 +44,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       }
     }
 
-    function addListeners() {
-      fp._bind(fp.prevMonthNav, "click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        fp.changeYear(fp.currentYear - 1);
-        selectYear();
-      });
-
-      fp._bind(fp.nextMonthNav, "click", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        fp.changeYear(fp.currentYear + 1);
-        selectYear();
-      });
-    }
-
-    function addMonths() {
+    function buildMonths() {
       if (!fp.rContainer) return;
 
       self.monthsContainer = fp._createElement<HTMLDivElement>(
@@ -91,16 +72,44 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         if (
           (fp.config.minDate && month.dateObj < fp.config.minDate) ||
           (fp.config.maxDate && month.dateObj > fp.config.maxDate)
-        ) {
+        )
           month.classList.add("disabled");
-        }
+        if (month.dateObj.getMonth() === new Date().getMonth() &&
+          month.dateObj.getFullYear() === new Date().getFullYear())
+          month.classList.add("today");
+        if (month.dateObj.getMonth() === fp.selectedDates[0]?.getMonth() &&
+          month.dateObj.getFullYear() === fp.selectedDates[0]?.getFullYear())
+          month.classList.add("selected");
       }
 
       fp.rContainer.appendChild(self.monthsContainer);
     }
 
+    function bindEvents() {
+      fp._bind(fp.prevMonthNav, "click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        fp.changeYear(fp.currentYear - 1);
+        selectYear();
+        if (fp.rContainer) clearNode(fp.rContainer);
+        buildMonths();
+      });
+
+      fp._bind(fp.nextMonthNav, "click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        fp.changeYear(fp.currentYear + 1);
+        selectYear();
+        if (fp.rContainer) clearNode(fp.rContainer);
+        buildMonths();
+      });
+    }
+
     function setCurrentlySelected() {
       if (!fp.rContainer) return;
+      if (!fp.selectedDates.length) return;
 
       const currentlySelected = fp.rContainer.querySelectorAll(
         ".flatpickr-monthSelect-month.selected"
@@ -110,7 +119,7 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         currentlySelected[index].classList.remove("selected");
       }
 
-      const targetMonth = (fp.selectedDates[0] || new Date()).getMonth();
+      const targetMonth = fp.selectedDates[0].getMonth();
       const month = fp.rContainer.querySelector(
         `.flatpickr-monthSelect-month:nth-child(${targetMonth + 1})`
       );
@@ -244,8 +253,8 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
           fp.currentMonth = 0;
         },
         clearUnnecessaryDOMElements,
-        addListeners,
-        addMonths,
+        buildMonths,
+        bindEvents,
         setCurrentlySelected,
         () => {
           fp.loadedPlugins.push("monthSelect");

--- a/src/plugins/monthSelect/style.css
+++ b/src/plugins/monthSelect/style.css
@@ -5,8 +5,8 @@
 
 .flatpickr-monthSelect-month {
   background: none;
-  border: 0;
-  border-radius: 2px;
+  border: 1px solid transparent;
+  border-radius: 4px;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   color: #393939;
@@ -52,6 +52,10 @@
   color: rgba(255, 255, 255, 0.95);
 }
 
+.flatpickr-monthSelect-month.today {
+  border-color: #959ea9;
+}
+
 .flatpickr-monthSelect-month:hover,
 .flatpickr-monthSelect-month:focus {
   background: #e6e6e6;
@@ -63,6 +67,13 @@
 .flatpickr-monthSelect-theme-dark .flatpickr-monthSelect-month:focus {
   background: #646c8c;
   border-color: #646c8c;
+}
+
+.flatpickr-monthSelect-month.today:hover,
+.flatpickr-monthSelect-month.today:focus {
+  background: #959ea9;
+  border-color: #959ea9;
+  color: #fff;
 }
 
 .flatpickr-monthSelect-month.selected {


### PR DESCRIPTION
This commit corrects a mismatch in the CSS/styling
of the default date select mode
and the monthSelect plugin.

Specifically, when default flatpickr is newly instantiated:

* `.selected` is applied to nothing, and
* `.today` is applied to the current date.

When flatpickr is newly instantiated with the monthSelect plugin:

* `.selected` is applied to the current date, and
* `.today` is applied to nothing.

(Importantly, the current date is not actually selected by default,
meaning that the UI does not reflect the underlying calendar state.)

To fix this, monthSelect's DOM management had to be expanded:
before, it simply drew the calendar grid once,
and paging through previous/future years had no influence
on which cell was marked `.selected`;
now, it clears and redraws the calendar grid with each page change
so that the `.today` and `.selected` cells come and go as needed.