### PR TITLE
Fix for picker showing and hiding again

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -636,7 +636,7 @@ describe("flatpickr", () => {
       fp._input.focus();
 
       expect(fp.isOpen).toBe(true);
-      simulate("click", window.document.body, { which: 1 }, CustomEvent);
+      simulate("mousedown", window.document.body, { which: 1 }, CustomEvent);
       fp._input.blur();
 
       expect(fp.isOpen).toBe(false);
@@ -653,7 +653,7 @@ describe("flatpickr", () => {
       expect(fp.selectedDates.length).toBe(1);
 
       fp.isOpen = true;
-      simulate("click", window.document.body, { which: 1 }, CustomEvent);
+      simulate("mousedown", window.document.body, { which: 1 }, CustomEvent);
       expect(fp.isOpen).toBe(false);
       expect(fp.selectedDates.length).toBe(0);
       expect(fp._input.value).toBe("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,11 +423,11 @@ function FlatpickrInstance(
 
     if (window.ontouchstart !== undefined)
       bind(window.document, "touchstart", documentClick);
-    else bind(window.document, "click", documentClick);
+    else bind(window.document, "mousedown", documentClick);
     bind(window.document, "focus", documentClick, { capture: true });
 
     bind(self._input, "focus", self.open);
-    bind(self._input, "click", self.open);
+    bind(self._input, "mousedown", self.open);
 
     if (self.daysContainer !== undefined) {
       bind(self.monthNav, "click", onMonthNavClick);


### PR DESCRIPTION
### Summary
I am proposing a reversion of the merge #2127, which addressed issue #2126. This commit made flatpickr use 'click' events instead of 'mousedown' events in order to be compatible with [WCAG 2.1](https://www.w3.org/TR/WCAG21), specifically [2.5.2 Pointer Cancellation](https://www.w3.org/TR/WCAG21/#pointer-cancellation).

### Reasoning
This change has introduced some strange behaviour in flatpickr because of the way that 'click' works. The fact that flatpickr runs identical events for both focus and click events ensures that compatibility with WCAG 2.1 - 2.5.2 is not possible. Think of the following scenario:

**A user 'clicks' into a flatpickr input field:**
- The browser fires a Focus event - flatpickr runs self.open (therefore invalidating WCAG 2.1 compatibility as there is no way of cancelling this event)
- The browser fires a Mousedown event - the element under the pointer is 'self._input'. The target of the event is registered as such. Flatpickr does nothing, but is still drawing the calendar since self.open got called in the Focus event
- Flatpickr finishes drawing the calendar, and the div is visible underneath the pointer
- The user releases the pointing device,  triggering a 'mouseup' event. Because the user took ~50ms to release the 'click', the 'mouseup' target element is now the flatpickrcalendar div.
- The 'click' event is fired, but with the document as the target instead of the self._input, because the overall target of the combination of 'mousedown' and 'mouseup' was the document, not self._input. This means that self.open is not run a second time, but the documentClick method is run (because this is registered to run on a document.onClick).
- documentClick sees that the picker is open, figures that the 'click' event occured outside of the flatpickr element and forces the flatpickr to close.

TL;DR - If you click too slowly, and flatpickr draws under your mouse, the browser gets confused and thinks you're clicking somewhere else, closing flatpickr.


### Solution
The solution to this is to move back to using 'mousedown' events. This ensures the correct event target is being used every time. While this does mean that in theory flatpickr isn't compatible with WCAG 2.1 - 2.5.2, the reality is that this is already moot as the plugin does a draw on the Focus event, meaning that the actual behaviour of the plugin is as if it is using 'mousedown' anyway, and it doesn't allow for cancellation of that event (except in the exact case detailed above, which isn't desired behaviour).

This PR directly addresses issue #2286. I thought of making this more complicated by using some sort of latestMousedown Target buffer on the click event or something, but it all ends up in the same place; in my opinion moving back to 'mousedown' is the most elegant solution.