### PR TITLE
add monthAriaLabel

### DIFF
--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -56,6 +56,7 @@ export const Japanese: CustomLocale = {
   time_24hr: true,
   rangeSeparator: " から ",
   firstDayOfWeek: 1,
+  monthAriaLabel: '月',
 };
 
 fp.l10ns.ja = Japanese;

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -70,6 +70,7 @@ export type CustomLocale = {
   toggleTitle?: Locale["toggleTitle"];
   scrollTitle?: Locale["scrollTitle"];
   yearAriaLabel?: string;
+  monthAriaLabel?: string;
   hourAriaLabel?: string;
   minuteAriaLabel?: string;
   amPM?: Locale["amPM"];


### PR DESCRIPTION
monthAriaLabel added default l10n but, didn't add custom l10n. so add attributes and Japanese translation.

![image](https://user-images.githubusercontent.com/8898432/96393750-0992a100-11fb-11eb-8d6f-022dd807afcb.png)
reference https://github.com/flatpickr/flatpickr/pull/2082