### PR TITLE
add option disableKeyDownBinding to partially fix #1444, #1387

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -416,7 +416,8 @@ function FlatpickrInstance(
           onMouseOver(getEventTarget(e) as DayElement);
       });
 
-    bind(window.document.body, "keydown", onKeyDown);
+    if(!self.config.disableKeyDownBinding)
+      bind(window.document.body, "keydown", onKeyDown);
 
     if (!self.config.inline && !self.config.static)
       bind(window, "resize", debouncedResize);
@@ -1972,6 +1973,7 @@ function FlatpickrInstance(
       "static",
       "enableSeconds",
       "disableMobile",
+      "disableKeyDownBinding",
     ];
 
     const userConfig = {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -120,6 +120,9 @@ export interface BaseOptions {
 By default, Flatpickr utilizes native datetime widgets unless certain options (e.g. disable) are used. */
   disableMobile: boolean;
 
+  /** Disable keyDown binding will stop monotoring keydown events, in some cases user only wants to use mouse/touch to select a date and leave the input as readonly. */
+  disableKeyDownBinding: boolean;
+
   /* Disables all dates except these specified. See https://chmln.github.io/flatpickr/examples/#disabling-all-dates-except-select-few */
   enable: DateLimit<DateOption>[];
 
@@ -288,6 +291,7 @@ export interface ParsedOptions {
   disable: DateLimit<Date>[];
   disableMobile: boolean;
   enable?: DateLimit<Date>[];
+  disableKeyDownBinding?: boolean;
   enableSeconds: boolean;
   enableTime: boolean;
   errorHandler: (err: Error) => void;
@@ -353,6 +357,7 @@ export const defaults: ParsedOptions = {
   defaultSeconds: 0,
   disable: [],
   disableMobile: false,
+  disableKeyDownBinding: false,
   enableSeconds: false,
   enableTime: false,
   errorHandler: (err: Error) =>


### PR DESCRIPTION
- Disable keyDown binding will stop monotoring keydown events, in some cases user only wants to use mouse/touch to select a date and leave the input as readonly.
- the onKeyDown is a little too agressive and conflicts with other inputs/keystrokes outside of flatpickr, disabling the binding is a good alternative
- this partially address issues #1387 and #1444 by providing a way to disable the keydown event listener
- this also fixes an issue found in my lib (Angular-Slickgrid) by another user which is causing huge performance decrease because the Flatpickr keydown listener is listening for every input in the page (even non-Flatpickr inputs), see this [comment](https://github.com/ghiscoding/Angular-Slickgrid/issues/625#issuecomment-726590619)