### PR TITLE
The first day of the week in japan is Sunday instead of Monday.

### DIFF
--- a/src/l10n/ja.ts
+++ b/src/l10n/ja.ts
@@ -55,7 +55,6 @@ export const Japanese: CustomLocale = {
   },
   time_24hr: true,
   rangeSeparator: " から ",
-  firstDayOfWeek: 1,
   monthAriaLabel: '月',
   amPM: ["午前", "午後"],
   yearAriaLabel: "年",


### PR DESCRIPTION
Revert "Merge pull request #1846 from lightsound/update-ja"

I think that the first day of the week in japan is Sunday instead of Monday.
There are two reasons.

The first one is that the Kojien (Japanese Dictionary) says that Sunday is
first day of the week.
The second one is that Labor Standards Act in Japan says the default
week is Sunday to Saturday. [昭63.1.1 基発1号](https://www.mhlw.go.jp/web/t_doc?dataId=00tb1899&dataType=1&pageNo=1)

Because of these two reasons, The first day of the week is Sunday.

Also most  the first day of the week of [Japanese Calendar(Google Search)](https://www.google.com/search?q=%E6%97%A5%E6%9C%AC%E3%80%80%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC&tbm=isch&ved=2ahUKEwjD8a27o53tAhUKzJQKHTjVAw8Q2-cCegQIABAA&oq=%E6%97%A5%E6%9C%AC%E3%80%80%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC&gs_lcp=CgNpbWcQAzICCAAyAggAMgIIADICCAA6BggAEAcQHjoHCAAQsQMQBDoKCAAQsQMQgwEQBDoICAAQsQMQgwE6BAgAEAQ6CAgAELEDELEDOgUIABCxAzoECAAQGDoECAAQFzoGCAAQGBAXUMxKWO5gYMhjaABwAHgAgAF6iAHdDZIBBDMuMTSYAQCgAQGqAQtnd3Mtd2l6LWltZ8ABAQ&sclient=img&ei=wBW-X8ORKoqY0wS4qo94&bih=986&biw=1792) are Sunday.