### PR TITLE
Fixed customElements with shadow DOM positioning issues

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -17,8 +17,20 @@
         "Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
     }
 
+    label {
+      display: block;
+    }
+
     label > div {
       margin-bottom: 4px;
+    }
+
+    label + label {
+      margin-top: 2rem;
+    }
+
+    .container {
+      float: right;
     }
   </style>
 </head>
@@ -30,12 +42,17 @@
         <input placeholder="Select Date..." class=date />
       </label>
 
-      <!--
       <label>
-        <div>Date 2</div>
-        <input placeholder="Select Date..." class=date id=input2 />
+        <div>Positioned datepicker</div>
+        <div class="container">
+          <input placeholder="Select Date..." class="positioned-date" />
+        </div>
       </label>
-      -->
+
+      <label>
+        <div>Custom element datepicker</div>
+        <custom-datepicker></custom-datepicker>
+      </label>
     </div>
   </div>
   
@@ -50,9 +67,55 @@
   <script src="./dist/plugins/weekSelect/weekSelect.js"></script>
 
   <script>
-    var fp = flatpickr(".date", {
+    var fp = flatpickr(".date", {});
+    var fp2 = flatpickr(".positioned-date", {
+      'positionElement': this.input
+    });
+  </script>
 
-    })
+  <script>
+    class CustomDatepicker extends HTMLElement {
+      constructor() {
+        super();
+        this._shadow = this.attachShadow({mode: 'open'});
+        this._shadow.innerHTML = `
+          <style>
+            @import 'dist/flatpickr.css';
+            @import 'dist/ie.css';
+            @import 'dist/plugins/confirmDate/confirmDate.css';
+            @import 'dist/plugins/monthSelect/style.css';
+
+            #container {
+              position: relative;
+              width: 100%;
+            }
+
+            input {
+              float: right;
+            }
+          </style>
+          <div id="container">
+            <input placeholder="Select Date..." class="date" />
+          </div>
+        `;
+      }
+
+      get container() {
+        return this.shadowRoot.querySelector('#container');
+      }
+
+      get input() {
+        return this.container.querySelector('input');
+      }
+
+      connectedCallback() {
+        this._flatpickr = flatpickr(this.container, {
+          'positionElement': this.input,
+          'appendTo': this.container
+        });
+      }
+    }
+    customElements.define('custom-datepicker', CustomDatepicker);
   </script>
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2161,7 +2161,15 @@ function FlatpickrInstance(
       configPos = self.config.position.split(" "),
       configPosVertical = configPos[0],
       configPosHorizontal = configPos.length > 1 ? configPos[1] : null,
-      inputBounds = positionElement.getBoundingClientRect(),
+      inputBounds = self.config.appendTo
+        ? {
+            top: positionElement.offsetHeight,
+            bottom: positionElement.offsetTop,
+            left: positionElement.offsetLeft,
+            right: positionElement.offsetWidth,
+            width: positionElement.clientWidth,
+          }
+        : positionElement.getBoundingClientRect(),
       distanceFromBottom = window.innerHeight - inputBounds.bottom,
       showOnTop =
         configPosVertical === "above" ||
@@ -2169,10 +2177,11 @@ function FlatpickrInstance(
           distanceFromBottom < calendarHeight &&
           inputBounds.top > calendarHeight);
 
-    const top =
-      window.pageYOffset +
-      inputBounds.top +
-      (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
+    const top = self.config.appendTo
+      ? inputBounds.top + (!showOnTop ? 2 : -calendarHeight - 2)
+      : window.pageYOffset +
+        inputBounds.top +
+        (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2);
 
     toggleClass(self.calendarContainer, "arrowTop", !showOnTop);
     toggleClass(self.calendarContainer, "arrowBottom", showOnTop);


### PR DESCRIPTION
We've had some positioning issues when flatpickr is combined with customElements with a shadow DOM. Apparently more people are affected by this issue. I've provided an example implementation to reproduce this issue:

<img width="2560" alt="1" src="https://user-images.githubusercontent.com/11139249/102780697-ac4fd300-4396-11eb-995f-cb991ffbcb4b.png">

I've made some code changes that fix this issue and does not have a negative impact on other positioning and the unit tests:

<img width="2560" alt="2" src="https://user-images.githubusercontent.com/11139249/102780749-c5f11a80-4396-11eb-926f-2116eb58cb7c.png">

Didn't added unit tests to cover this code changes, but willing to provide it if the PR has a chance of being merged.