### PR TITLE
chore: replace CircleCI status badge with GitHub Actions status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: 'tests'
+name: 'GitHub Actions'
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## flatpickr - javascript datetime picker
-[![Actions Status](https://github.com/ghiscoding/slickgrid-universal/workflows/GitHub%20Actions/badge.svg)](https://github.com/flatpickr/flatpickr)
+[![Actions Status](https://github.com/ghiscoding/slickgrid-universal/workflows/GitHub%20Actions/badge.svg)](https://github.com/flatpickr/flatpickr/actions)
 
 [![Coverage](https://coveralls.io/repos/github/chmln/flatpickr/badge.svg?branch=master)](https://coveralls.io/github/chmln/flatpickr)
 [![npm version](https://badge.fury.io/js/flatpickr.svg)](https://www.npmjs.com/package/flatpickr)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## flatpickr - javascript datetime picker
-[![Build Status](https://circleci.com/gh/flatpickr/flatpickr/tree/master.svg?style=shield)](https://circleci.com/gh/flatpickr/flatpickr/tree/master)
+[![Actions Status](https://github.com/ghiscoding/slickgrid-universal/workflows/GitHub%20Actions/badge.svg)](https://github.com/flatpickr/flatpickr)
 
 [![Coverage](https://coveralls.io/repos/github/chmln/flatpickr/badge.svg?branch=master)](https://coveralls.io/github/chmln/flatpickr)
 [![npm version](https://badge.fury.io/js/flatpickr.svg)](https://www.npmjs.com/package/flatpickr)


### PR DESCRIPTION
- the GitHub Actions badge must match the "name" (from workflow) for it to pull the status

This is show the correct status badge after Flatpickr switch to GitHub Actions around Christmas and if you prefer a different name in the badge, like "CI Status" or anything else let me know. 

![image](https://user-images.githubusercontent.com/643976/104507474-d0c55680-55b4-11eb-87da-324a1714fe94.png)
