### PR TITLE
Fix for calendar position on Safari

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2220,6 +2220,7 @@ function FlatpickrInstance(
     let editableSheet = null;
     for (let i = 0; i < document.styleSheets.length; i++) {
       const sheet = document.styleSheets[i] as CSSStyleSheet;
+      if (!sheet.cssRules) continue;
       try {
         sheet.cssRules;
       } catch (err) {


### PR DESCRIPTION
## Summary
On Safari (I'm using 14.0.2 but it occurs in other versions as well)
When the calendar doesn't fit into the screen and has to be repositioned
And the first imported stylesheet on the page is from another domain (explained below)

The function `positionCalendar` throws an error on `doc.cssRules.length`
![Screen Shot 2021-01-19 at 20 39 55](https://user-images.githubusercontent.com/2248378/105090612-64979680-5a7d-11eb-8141-8988c54e1f0d.png)

After some research and [this post](https://medium.com/better-programming/how-to-fix-the-failed-to-read-the-cssrules-property-from-cssstylesheet-error-431d84e4a139) I found out that the `cssRules` list cannot be accessed when the imported stylesheet is from another domain. I stumbled on this because my first stylesheet import was a Google font.
On Safari, unlike other browsers, the cssRules node comes as `null` and gives a "false positive" on `getDocumentStyleSheet` method.

My approach was to just check if the node is set before the try/catch block.
