### PR TITLE
Add missing horizontal position strings to position option type

### DIFF
--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -229,6 +229,15 @@ Use it along with "enableTime" to create a time picker. */
     | "auto"
     | "above"
     | "below"
+    | "auto left"
+    | "auto center"
+    | "auto right"
+    | "above left"
+    | "above center"
+    | "above right"
+    | "below left"
+    | "below center"
+    | "below right"
     | ((self: Instance, customElement: HTMLElement | undefined) => void);
 
   /*


### PR DESCRIPTION
Include strings for horizontal positioning in the `BaseOptions` interface `position` property.