### PR TITLE
Revert this code causes a major inability to clear date/time values.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1437,6 +1437,8 @@ function FlatpickrInstance(
       );
 
       if (lostFocus && isIgnored) {
+
+        /* THIS CAUSES THE INABILITY TO CLEAR THE DATE/TIME VALUES
         if (
           self.timeContainer !== undefined &&
           self.minuteElement !== undefined &&
@@ -1446,6 +1448,7 @@ function FlatpickrInstance(
         ) {
           updateTime();
         }
+        */
 
         self.close();
 


### PR DESCRIPTION
The date/time values cannot be cleared with backspace or escape once a value is set.  This is a major usability issue as reported in multiple issues #2040, #2173, #2038.  

Removing this block of code does not appear to have any negative side effects.