### PR TITLE
fix: handling document click after manual update 

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -849,7 +849,7 @@ describe("flatpickr", () => {
       expect(fp.currentMonth).toEqual(0);
     });
 
-    it("sets the date on direct entry when allowInput is true", () => {
+    it("sets the date on direct entry when allowInput is true - blur", () => {
       createInstance({ allowInput: true });
       expect(fp.selectedDates[0]).toBeUndefined();
 
@@ -863,7 +863,7 @@ describe("flatpickr", () => {
       expect(fp.selectedDates[0].getDate()).toEqual(31);
     });
 
-    it("updates the date on direct entry when allowInput is true", () => {
+    it("updates the date on direct entry when allowInput is true - blur", () => {
       createInstance({
         allowInput: true,
         enableTime: true,
@@ -878,6 +878,47 @@ describe("flatpickr", () => {
 
       fp.input.focus();
       fp.input.value = "1969-07-20 20:17";
+      fp.input.blur();
+
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(1969);
+      expect(fp.selectedDates[0].getMonth()).toEqual(6); // 6 === July
+      expect(fp.selectedDates[0].getDate()).toEqual(20);
+      expect(fp.selectedDates[0].getHours()).toEqual(20);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(17);
+    });
+
+    it("sets the date on direct entry when allowInput is true - document click", () => {
+      createInstance({ allowInput: true });
+      expect(fp.selectedDates[0]).toBeUndefined();
+
+      fp.input.focus();
+      fp.input.value = "1999-12-31";
+      clickOn(document.body);
+      fp.input.blur();
+
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(1999);
+      expect(fp.selectedDates[0].getMonth()).toEqual(11); // 11 === December
+      expect(fp.selectedDates[0].getDate()).toEqual(31);
+    });
+
+    it("updates the date on direct entry when allowInput is true - document click", () => {
+      createInstance({
+        allowInput: true,
+        enableTime: true,
+        defaultDate: "2001-01-01 01:01",
+      });
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(2001);
+      expect(fp.selectedDates[0].getMonth()).toEqual(0); // 0 === January
+      expect(fp.selectedDates[0].getDate()).toEqual(1);
+      expect(fp.selectedDates[0].getHours()).toEqual(1);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(1);
+
+      fp.input.focus();
+      fp.input.value = "1969-07-20 20:17";
+      clickOn(document.body);
       fp.input.blur();
 
       expect(fp.selectedDates[0]).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1624,6 +1624,7 @@ function FlatpickrInstance(
             ? self.config.altFormat
             : self.config.dateFormat
         );
+        self.close();
         return (eventTarget as HTMLElement).blur();
       } else {
         self.open();

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,12 +188,17 @@ function FlatpickrInstance(
       timeWrapper(e);
     }
 
-    const prevValue = self._input.value;
-
-    setHoursFromInputs();
+    const valueFromInput = self._input.value;
+    const dateFromInput = self.parseDate(valueFromInput);
+    if (dateFromInput && self.latestSelectedDateObj && dateFromInput.getTime() !== self.latestSelectedDateObj.getTime()) {
+      self.selectedDates.splice(self.selectedDates.length-1, 1, self.latestSelectedDateObj = dateFromInput);
+      setHours(dateFromInput.getHours(), dateFromInput.getMinutes(), dateFromInput.getSeconds());
+    } else {
+      setHoursFromInputs();
+    }
     updateValue();
 
-    if (self._input.value !== prevValue) {
+    if (self._input.value !== valueFromInput) {
       self._debouncedChange();
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,9 +190,9 @@ function FlatpickrInstance(
 
     const valueFromInput = self._input.value;
     const dateFromInput = self.parseDate(valueFromInput);
-    if (dateFromInput && self.latestSelectedDateObj && dateFromInput.getTime() !== self.latestSelectedDateObj.getTime()) {
-      self.selectedDates.splice(self.selectedDates.length-1, 1, self.latestSelectedDateObj = dateFromInput);
-      setHours(dateFromInput.getHours(), dateFromInput.getMinutes(), dateFromInput.getSeconds());
+    const latestDate = self.latestSelectedDateObj;
+    if (valueFromInput && latestDate && dateFromInput?.getTime() !== latestDate?.getTime()) {
+      setDate(dateFromInput!);
     } else {
       setHoursFromInputs();
     }


### PR DESCRIPTION
Primarily it fixes #2394 

**The cause of the issue**
When manual input is allowed, the user input was not respected, when a user clicks anywhere in the document body instead of pressing TAB key. This results in 'click'->'blur' event sequence as opposed to only a blur event. This results in setting the date always from the calendar element.

**The fix**
The fix compares the date from the input with the latest selected date; if it matches then the changes is coming from the calendar control and updates the date time from calendar control, as before. Otherwise the change is coming from the input control, and it simply overwrites the latest selected date. The synchronization step later takes care of the rest, as before.

Additionally, it contains changes to close the calendar popup when ENTER is pressed on the input field. This is similar to the ENTER handling behavior on the time input fields.
