### PR TITLE
[fix] apply positionElement to instance._positionElement when fp.set

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -513,6 +513,10 @@ describe("flatpickr", () => {
 
       fp.set("mode", "range");
       expect(fp.config.mode).toEqual("range");
+
+      const elem = document.createElement("div");
+      fp.set("positionElement", elem);
+      expect(fp._positionElement).toEqual(elem);
     });
 
     it("set() minDate/maxDate updates current view", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2361,7 +2361,7 @@ function FlatpickrInstance(
     showMonths: [buildMonths, setCalendarWidth, buildWeekdays],
     minDate: [jumpToDate],
     maxDate: [jumpToDate],
-    positionElement: [updatePotisionElement],
+    positionElement: [updatePositionElement],
     clickOpens: [
       () => {
         if (self.config.clickOpens === true) {
@@ -2595,10 +2595,10 @@ function FlatpickrInstance(
     if (!self.config.allowInput)
       self._input.setAttribute("readonly", "readonly");
 
-    updatePotisionElement();
+    updatePositionElement();
   }
 
-  function updatePotisionElement() {
+  function updatePositionElement() {
     self._positionElement = self.config.positionElement || self._input;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2361,6 +2361,7 @@ function FlatpickrInstance(
     showMonths: [buildMonths, setCalendarWidth, buildWeekdays],
     minDate: [jumpToDate],
     maxDate: [jumpToDate],
+    positionElement: [setupInputs],
     clickOpens: [
       () => {
         if (self.config.clickOpens === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2361,7 +2361,7 @@ function FlatpickrInstance(
     showMonths: [buildMonths, setCalendarWidth, buildWeekdays],
     minDate: [jumpToDate],
     maxDate: [jumpToDate],
-    positionElement: [setupInputs],
+    positionElement: [updatePotisionElement],
     clickOpens: [
       () => {
         if (self.config.clickOpens === true) {
@@ -2595,6 +2595,10 @@ function FlatpickrInstance(
     if (!self.config.allowInput)
       self._input.setAttribute("readonly", "readonly");
 
+    updatePotisionElement();
+  }
+
+  function updatePotisionElement() {
     self._positionElement = self.config.positionElement || self._input;
   }
 


### PR DESCRIPTION
Related issue: #2312

### The cause of issue
The fp instance appers based on `self._positionElement`.
When executing `fp.set()`, positionElement value is set to `self.config.positionElement` but no set to `self._positionElement`.

### The fix
Setting `self.config.positionElement` to `self._positionElement` is executed in `setupInputs()` method.
so add `updatePositionElement()` function and call that in `setupInputs()` and `CALLBACKS`
