### PR TITLE
Fix parseDate on relative inputs

### DIFF
--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -102,12 +102,12 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
             });
           }
         } else if (!isBackSlash) regexStr += "."; // don't really care
-
-        ops.forEach(
-          ({ fn, val }) =>
-            (parsedDate = fn(parsedDate as Date, val, locale) || parsedDate)
-        );
       }
+
+      ops.forEach(
+        ({ fn, val }) =>
+          (parsedDate = fn(parsedDate as Date, val, locale) || parsedDate)
+      );
 
       parsedDate = matched ? parsedDate : undefined;
     }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -79,11 +79,6 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
     ) {
       parsedDate = new Date(date);
     } else {
-      parsedDate =
-        !config || !config.noCalendar
-          ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0)
-          : (new Date(new Date().setHours(0, 0, 0, 0)) as Date);
-
       let matched,
         ops: { fn: RevFormatFn; val: string }[] = [];
 
@@ -103,6 +98,11 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
           }
         } else if (!isBackSlash) regexStr += "."; // don't really care
       }
+
+      parsedDate =
+        !config || !config.noCalendar
+          ? new Date(new Date().getFullYear(), 0, 1, 0, 0, 0, 0)
+          : (new Date(new Date().setHours(0, 0, 0, 0)) as Date);
 
       ops.forEach(
         ({ fn, val }) =>


### PR DESCRIPTION
Suppose the day is given as “0”. `date.setDate(0)` will set the day to the last of the previous month. With `ops.forEach` being inside the for loop this is done for every run through the loop, so for every loop we go one month back instead of only once.

For example `parseDate("0.", "d.m.Y")` gives 31.08.2020 instead of 31.12.2020.