### PR TITLE
Support reversed ranges for minTime and maxTime

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1273,6 +1273,30 @@ describe("flatpickr", () => {
       expect(fp.input.value).toEqual("02:30");
     });
 
+    it("time picker: minTime/maxTime reversed", () => {
+      createInstance({
+        enableTime: true,
+        minTime: "05:30",
+        maxTime: "03:30",
+        defaultDate: "2021-07-01 3:30",
+      });
+
+      fp.open();
+
+      expect(fp.input.value).toEqual("2021-07-01 03:30");
+
+      incrementTime("hourElement", +1);
+      expect(fp.input.value).toEqual("2021-07-01 05:30");
+
+      incrementTime("hourElement", +1);
+      expect(fp.input.value).toEqual("2021-07-01 06:30");
+
+      incrementTime("hourElement", -1);
+      incrementTime("hourElement", -1);
+      incrementTime("hourElement", -1);
+      expect(fp.input.value).toEqual("2021-07-01 05:30");
+    });
+
     it("time picker: minDate/maxDate + preloading", () => {
       createInstance({
         enableTime: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,31 +247,52 @@ function FlatpickrInstance(
         compareDates(self.latestSelectedDateObj, self.config.maxDate, true) ===
           0);
 
-    if (limitMaxHours) {
-      const maxTime =
-        self.config.maxTime !== undefined
-          ? self.config.maxTime
-          : (self.config.maxDate as Date);
-      hours = Math.min(hours, maxTime.getHours());
-      if (hours === maxTime.getHours())
-        minutes = Math.min(minutes, maxTime.getMinutes());
+    if (
+      self.config.maxTime !== undefined &&
+      self.config.minTime !== undefined &&
+      self.config.minTime > self.config.maxTime
+    ) {
+      if (
+        hours >= self.config.maxTime.getHours() &&
+        hours < self.config.minTime.getHours()
+      ) {
+        hours = self.config.minTime.getHours();
+        if (
+          hours === self.config.minTime.getHours() &&
+          minutes < self.config.minTime.getMinutes()
+        )
+          minutes = self.config.minTime.getMinutes();
 
-      if (minutes === maxTime.getMinutes())
-        seconds = Math.min(seconds, maxTime.getSeconds());
-    }
+        if (minutes === self.config.minTime.getMinutes())
+          seconds = Math.max(seconds, self.config.minTime.getSeconds());
+      }
+    } else {
+      if (limitMaxHours) {
+        const maxTime =
+          self.config.maxTime !== undefined
+            ? self.config.maxTime
+            : (self.config.maxDate as Date);
+        hours = Math.min(hours, maxTime.getHours());
+        if (hours === maxTime.getHours())
+          minutes = Math.min(minutes, maxTime.getMinutes());
 
-    if (limitMinHours) {
-      const minTime =
-        self.config.minTime !== undefined
-          ? self.config.minTime
-          : self.config.minDate!;
+        if (minutes === maxTime.getMinutes())
+          seconds = Math.min(seconds, maxTime.getSeconds());
+      }
 
-      hours = Math.max(hours, minTime.getHours());
-      if (hours === minTime.getHours() && minutes < minTime.getMinutes())
-        minutes = minTime.getMinutes();
+      if (limitMinHours) {
+        const minTime =
+          self.config.minTime !== undefined
+            ? self.config.minTime
+            : self.config.minDate!;
 
-      if (minutes === minTime.getMinutes())
-        seconds = Math.max(seconds, minTime.getSeconds());
+        hours = Math.max(hours, minTime.getHours());
+        if (hours === minTime.getHours() && minutes < minTime.getMinutes())
+          minutes = minTime.getMinutes();
+
+        if (minutes === minTime.getMinutes())
+          seconds = Math.max(seconds, minTime.getSeconds());
+      }
     }
 
     setHours(hours, minutes, seconds);


### PR DESCRIPTION
This feature is handy for creating maintenance windows or disabling time ranges.

For example minTime: 5:30, maxTime: 3:30 means that you can pick time from 5:30 to 3:30, which disables 3:30 to 5:30 range to be picked.

Fixes issue: https://github.com/flatpickr/flatpickr/issues/2260