### PR TITLE
Fix maxTime bound bug

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1278,12 +1278,18 @@ describe("flatpickr", () => {
         enableTime: true,
         minTime: "05:30",
         maxTime: "03:30",
-        defaultDate: "2021-07-01 3:30",
+        defaultDate: "2021-07-01 1:29",
       });
 
       fp.open();
 
-      expect(fp.input.value).toEqual("2021-07-01 03:30");
+      expect(fp.input.value).toEqual("2021-07-01 01:29");
+
+      incrementTime("hourElement", +1);
+      expect(fp.input.value).toEqual("2021-07-01 02:29");
+
+      incrementTime("hourElement", +1);
+      expect(fp.input.value).toEqual("2021-07-01 03:29");
 
       incrementTime("hourElement", +1);
       expect(fp.input.value).toEqual("2021-07-01 05:30");

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ import {
   duration,
   isBetween,
   getDefaultHours,
+  calculateSecondsSinceMidnight,
+  parseSeconds,
 } from "./utils/dates";
 
 import { tokenRegex, monthToStr } from "./utils/formatting";
@@ -252,19 +254,27 @@ function FlatpickrInstance(
       self.config.minTime !== undefined &&
       self.config.minTime > self.config.maxTime
     ) {
-      if (
-        hours >= self.config.maxTime.getHours() &&
-        hours < self.config.minTime.getHours()
-      ) {
-        hours = self.config.minTime.getHours();
-        if (
-          hours === self.config.minTime.getHours() &&
-          minutes < self.config.minTime.getMinutes()
-        )
-          minutes = self.config.minTime.getMinutes();
+      const minBound = calculateSecondsSinceMidnight(
+        self.config.minTime.getHours(),
+        self.config.minTime.getMinutes(),
+        self.config.minTime.getSeconds()
+      );
+      const maxBound = calculateSecondsSinceMidnight(
+        self.config.maxTime.getHours(),
+        self.config.maxTime.getMinutes(),
+        self.config.maxTime.getSeconds()
+      );
+      const currentTime = calculateSecondsSinceMidnight(
+        hours,
+        minutes,
+        seconds
+      );
 
-        if (minutes === self.config.minTime.getMinutes())
-          seconds = Math.max(seconds, self.config.minTime.getSeconds());
+      if (currentTime > maxBound && currentTime < minBound) {
+        const result = parseSeconds(minBound);
+        hours = result[0];
+        minutes = result[1];
+        seconds = result[2];
       }
     } else {
       if (limitMaxHours) {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -154,6 +154,20 @@ export const isBetween = (ts: number, ts1: number, ts2: number) => {
   return ts > Math.min(ts1, ts2) && ts < Math.max(ts1, ts2);
 };
 
+export const calculateSecondsSinceMidnight = (
+  hours: number,
+  minutes: number,
+  seconds: number
+) => {
+  return hours * 3600 + minutes * 60 + seconds;
+};
+
+export const parseSeconds = (secondsSinceMidnight: number) => {
+  const hours = Math.floor(secondsSinceMidnight / 3600),
+    minutes = (secondsSinceMidnight - hours * 3600) / 60;
+  return [hours, minutes, secondsSinceMidnight - hours * 3600 - minutes * 60];
+};
+
 export const duration = {
   DAY: 86400000,
 };


### PR DESCRIPTION
With setting maxBound 3:30 (am) and minBound 5:30 (am) the previous implementation would set time as 5:30 (am) for 3:20 (am), which is incorrect.