### PR TITLE
Append to container and children no longer classed as calendar elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1433,9 +1433,6 @@ function FlatpickrInstance(
   }
 
   function isCalendarElem(elem: HTMLElement) {
-    if (self.config.appendTo && self.config.appendTo.contains(elem))
-      return true;
-
     return self.calendarContainer.contains(elem);
   }
 


### PR DESCRIPTION
Fix for #2054 

**The issue**
When using the appendTo option, the append to container and any children are classed as "Calendar elements". This prevents the calendar from closing when clicking outside of the calendar instance if the click target is a child of the appendTo element. 

**Fix**
Don't class the appendTo node/element as calendar elements, just the calendar instance, and its child nodes.


