### PR TITLE
Remove repeating 'onChange' trigger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -474,7 +474,6 @@ function FlatpickrInstance(
       if (self.amPM !== undefined) {
         bind(self.amPM, "click", (e) => {
           updateTime(e);
-          triggerChange();
         });
       }
     }


### PR DESCRIPTION
#2499 

Already triggering 'onChange' emitter in updateTime method. 

- `updateTime`:
```
if (self._input.value !== prevValue) {
  self._debouncedChange();
}
```
- `bindEvents` :
```
if (self.amPM !== undefined) {
  bind(self.amPM, "click", (e) => {
    updateTime(e);
    triggerChange();
  });
}
```