### PR TITLE
Keyboard doesn't work inside Shadow Dom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ function FlatpickrInstance(
   function getClosestActiveElement() {
     return (self.calendarContainer?.getRootNode() as unknown as DocumentOrShadowRoot).activeElement || document.activeElement;
   }
+
   function bindToInstance<F extends Function>(fn: F): F {
     return fn.bind(self);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,9 @@ function FlatpickrInstance(
     triggerEvent("onReady");
   }
 
+  function getClosestActiveElement() {
+    return (self.calendarContainer?.getRootNode() as unknown as DocumentOrShadowRoot).activeElement || document.activeElement;
+  }
   function bindToInstance<F extends Function>(fn: F): F {
     return fn.bind(self);
   }
@@ -812,12 +815,14 @@ function FlatpickrInstance(
   }
 
   function focusOnDay(current: DayElement | undefined, offset: number) {
-    const dayFocused = isInView(document.activeElement || document.body);
+    const activeElement = getClosestActiveElement();
+
+    const dayFocused = isInView(activeElement || document.body);
     const startElem =
       current !== undefined
         ? current
         : dayFocused
-        ? (document.activeElement as DayElement)
+        ? (activeElement as DayElement)
         : self.selectedDateElem !== undefined && isInView(self.selectedDateElem)
         ? self.selectedDateElem
         : self.todayDateElem !== undefined && isInView(self.todayDateElem)
@@ -1691,10 +1696,11 @@ function FlatpickrInstance(
           if (!isTimeObj && !isInput) {
             e.preventDefault();
 
+            const activeElement = getClosestActiveElement();
             if (
               self.daysContainer !== undefined &&
               (allowInput === false ||
-                (document.activeElement && isInView(document.activeElement)))
+                (activeElement && isInView(activeElement)))
             ) {
               const delta = e.keyCode === 39 ? 1 : -1;
 


### PR DESCRIPTION
When you initialize the flatpickr inside a shadow dom, the the usage via keyboard doesn't work.

The activeElement from the document is the component with the shadow dom. So the condition which checks if the activeElement is inside the flatpickr instance, doesn't match.
I fixed this by get the rootNode from the calendarContainer, in normal case, it is the document. In a WebComponent, it is the Shadow DOM.