### PR TITLE
Eliminate memory leak caused by event listener accumulation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,7 @@ function FlatpickrInstance(
 
     element.addEventListener(event, handler, options);
     self._handlers.push({
-      remove: () => element.removeEventListener(event, handler),
+      remove: () => element.removeEventListener(event, handler, options),
     });
   }
 


### PR DESCRIPTION
## Goal

Eliminate a memory leak caused by the accumulation of capturing event listeners created by Flatpickr as `FlatpickrInstance`s are created and destroyed (reported in #2595).

## How can this be tested locally?

### Observe the Problem

1. Checkout the destination branch.
2. `npm install`
3. `npm start`
4. Navigate to http://127.0.0.1:8000
5. Open dev tools to the JavaScript console.
6. Log the `document` listeners: `console.table(getEventListeners(window.document))`
7. Destroy the `FlatpickrInstance`: `fp.destroy()`
8. Log the `document` listeners: `console.table(getEventListeners(window.document))`
9. Observe that the `focus` listener is still present.

### Verify the Solution

1. Checkout the source branch.
2. `npm install`
3. `npm start`
4. Navigate to http://127.0.0.1:8000
5. Open dev tools to the JavaScript console.
6. Log the `document` listeners: `console.table(getEventListeners(window.document))`
7. Destroy the `FlatpickrInstance`: `fp.destroy()`
8. Log the `document` listeners: `console.table(getEventListeners(window.document))`
9. Verify that no listeners are logged.

## Comments

I'm happy to add automated tests for this, but I'm unsure what, if any would be appropriate.

This may also fix #1908. However, I have not verified that no other leaks remain.