### PR TITLE
Fix #2541 breaking with altInput enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1479,14 +1479,15 @@ function FlatpickrInstance(
 
       if (lostFocus && isIgnored) {
         if (self.config.allowInput) {
-          self.setDate(self._input.value, 
-            true, 
-            eventTarget === self.altInput
+          self.setDate(
+            self._input.value,
+            true,
+            self.config.altInput
               ? self.config.altFormat
               : self.config.dateFormat
           );
         }
-        
+
         if (
           self.timeContainer !== undefined &&
           self.minuteElement !== undefined &&


### PR DESCRIPTION
In the current master `allowInput: true` with `altInput: true` behaves terribly, it modifies the date value every time focusing and unfocusing on the flatpickr input element.

Refs. #2541