### PR TITLE
Prevent text selection on prev/next month buttons

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -177,6 +177,7 @@
     flex 1
 
   .flatpickr-prev-month, .flatpickr-next-month
+    user-select none
     text-decoration none
     cursor pointer
     position absolute


### PR DESCRIPTION
Fixes #2602 

This PR proposes a fix by adding `user-select: none` to the previous/next month buttons to prevent text from inadvertently being selected.