### PR TITLE
Fix for #2393 - "Enter a valid date" error on iOS Safari with default datetime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2672,7 +2672,7 @@ function FlatpickrInstance(
 
     self.mobileFormatStr =
       inputType === "datetime-local"
-        ? "Y-m-d\\TH:i:S"
+        ? "Y-m-d\\TH:i"
         : inputType === "date"
         ? "Y-m-d"
         : "H:i:S";


### PR DESCRIPTION
Using a format without seconds for the mobile native datetime value seems to have fixed this bug for me.

I was able to reproduce the bug by resetting the datetime form, opening it, pressing Done and then submitting my form. I was not able to reproduce if I clicked to a different date than the default when the format only has hours and minutes.

I tried inspecting the value of the mobile input element in mobile safari when the validation error happens and it seemed to be fine - current time in the `Y-m-d\TH:i:S` format. After clicking another time in the selector and hitting done, the time had the same format. It seems like a potential bug with datetime-local validation in mobile safari. I'm testing on iOS 15.1.1.


I am nervous that this change could cause an unexpected issue for someone. It doesn't cause an issue for me. I don't need seconds anyway. 

The test suite for flatpickr still passes after the update.

Anyway, I thought I'd share in case this helps someone. Thanks a lot.