### PR TITLE
Add formatDate default value

### DIFF
--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -366,6 +366,7 @@ export const defaults: ParsedOptions = {
   enableTime: false,
   errorHandler: (err: Error) =>
     typeof console !== "undefined" && console.warn(err),
+  formatDate: undefined,
   getWeek: (givenDate: Date) => {
     const date = new Date(givenDate.getTime());
     date.setHours(0, 0, 0, 0);


### PR DESCRIPTION
Hello, I just add default value to formatDate which is not "null" but "undefined" null value lead me to a bug in my app (if we put "null" if throw an error "config.formatDate is not a function"