### PR TITLE
Fixes confirmDate focus accessibility

### DIFF
--- a/src/plugins/confirmDate/confirmDate.ts
+++ b/src/plugins/confirmDate/confirmDate.ts
@@ -27,10 +27,15 @@ function confirmDatePlugin(pluginConfig: Config): Plugin {
     return {
       onKeyDown(_: Date[], __: string, ___: Instance, e: KeyboardEvent) {
         const eventTarget = getEventTarget(e);
+        const isTargetLastFocusableElement =
+          (!fp.config.time_24hr && eventTarget === fp.amPM) ||
+          (fp.config.time_24hr &&
+            ((fp.config.enableSeconds && eventTarget === fp.secondElement) ||
+              (!fp.config.enableSeconds && eventTarget === fp.minuteElement)));
         if (
           fp.config.enableTime &&
           e.key === "Tab" &&
-          eventTarget === fp.amPM
+          isTargetLastFocusableElement
         ) {
           e.preventDefault();
           confirmContainer.focus();


### PR DESCRIPTION
Currently `confirmDate` button can only be accessed via keyboard when `Tab` is pressed on AM/PM button.

This fixes it by allowing navigating to `confirmDate` button when `time_24hr: true` as well as when seconds are enabled/disabled.