### PR TITLE
Bug fix: error thrown and calendar UI broken by invalid input value when allowInput is true and allowInvalidPreload is true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -326,7 +326,7 @@ function FlatpickrInstance(
   function setHoursFromDate(dateObj?: Date) {
     const date = dateObj || self.latestSelectedDateObj;
 
-    if (date) {
+    if (date && date instanceof Date) {
       setHours(date.getHours(), date.getMinutes(), date.getSeconds());
     }
   }
@@ -2758,7 +2758,8 @@ function FlatpickrInstance(
 
   function isDateSelected(date: Date) {
     for (let i = 0; i < self.selectedDates.length; i++) {
-      if (compareDates(self.selectedDates[i], date) === 0) return "" + i;
+      const selectedDate = self.selectedDates[i];
+      if (selectedDate instanceof Date && compareDates(selectedDate, date) === 0) return "" + i;
     }
 
     return false;


### PR DESCRIPTION
Fixes #2649

When `allowInput` is true and `allowInvalidPreload` is true and user enters some invalid value into input, Flatpickr throws an error and calendar UI is broken, because of that error. This happens because there is invalid value in self.selectedDates (set by setSelectedDate() function), but code that is executed further in setDate() function assumes that all values in self.selectedDates are always valid Date objects. 
This fix adds two simple checks to make sure we are dealing with Date objects before using Date methods.

The error can be reproduced here: https://jsfiddle.net/yd07z3vo/1/