### PR TITLE
fixes #2669 monthSelectPlugin doesnt highlight correct month, when data is loaded

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -284,8 +284,8 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
     function stubCurrentMonth() {
       config._stubbedCurrentMonth = fp._initialDate.getMonth();
 
-      fp._initialDate.setMonth(0);
-      fp.currentMonth = 0;
+      fp._initialDate.setMonth(config._stubbedCurrentMonth);
+      fp.currentMonth = config._stubbedCurrentMonth;
     }
 
     function unstubCurrentMonth() {


### PR DESCRIPTION
stubCurrentMonth() simply defaulted the month to 0, instead of setting it to the actual selected month.

I've also updated the index.template.html, to demo this problem