### PR TITLE
Picker shouldn't open on focus (make this behaviour optional) 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -450,7 +450,9 @@ function FlatpickrInstance(
     bind(window.document, "focus", documentClick, { capture: true });
 
     if (self.config.clickOpens === true) {
-      bind(self._input, "focus", self.open);
+      if (self.config.focusOpens === true) {
+        bind(self._input, "focus", self.open);
+      }
       bind(self._input, "click", self.open);
     }
 
@@ -2422,7 +2424,9 @@ function FlatpickrInstance(
     clickOpens: [
       () => {
         if (self.config.clickOpens === true) {
-          bind(self._input, "focus", self.open);
+          if (self.config.focusOpens === true) {
+            bind(self._input, "focus", self.open);
+          }
           bind(self._input, "click", self.open);
         } else {
           self._input.removeEventListener("focus", self.open);

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -83,6 +83,13 @@ export interface BaseOptions {
     Set it to false if you only want to open the calendar programmatically
   */
   clickOpens: boolean;
+  /*
+     Option that when set to false calendar does not open on focus but 
+     instead only opens when the user interacts with it, either by clicking 
+     on the field with the mouse or pressing the down-arrow while the 
+     field is focussed.
+  */
+  focusOpens: boolean;
 
   /* Whether calendar should close after date selection */
   closeOnSelect: boolean;
@@ -287,6 +294,7 @@ export interface ParsedOptions {
   ariaDateFormat: string;
   autoFillDefaultTime: boolean;
   clickOpens: boolean;
+  focusOpens: boolean;
   closeOnSelect: boolean;
   conjunction: string;
   dateFormat: string;
@@ -354,6 +362,7 @@ export const defaults: ParsedOptions = {
   ariaDateFormat: "F j, Y",
   autoFillDefaultTime: true,
   clickOpens: true,
+  focusOpens: true,
   closeOnSelect: true,
   conjunction: ", ",
   dateFormat: "Y-m-d",


### PR DESCRIPTION
Fix for (https://github.com/flatpickr/flatpickr/issues/2703)

When the date picker input field is the first field in a modal dialog it should be focussed automatically (as per [web authoring standards](https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-7)) when the modal opens and thus the picker opens also, which is unexpected, annoying, distracting and can obscure some of the content of the modal.

Also, when tabbing through a large form, such as when skipping over optional fields, or navigating to a field to correct an error, if the user tabs through one or several date picker fields, this is annoying and distracting, adding cognitive load.