### PR TITLE
Fixed visual bug when selecting ranges with Month Select plugin.

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -152,9 +152,25 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       const month = fp.rContainer.querySelector(
         `.flatpickr-monthSelect-month:nth-child(${targetMonth + 1})`
       );
+      const months = fp.rContainer.querySelectorAll(
+        `.flatpickr-monthSelect-month`
+      );
+      const startRangeMonth = fp.rContainer.querySelector(`.startRange`);
+      const endRangeMonth = fp.rContainer.querySelector(`.endRange`);
 
       if (month) {
         month.classList.add("selected");
+        if (
+          startRangeMonth &&
+          endRangeMonth &&
+          !startRangeMonth.classList.contains("selected")
+        ) {
+          for (let index = 0; index < months.length; index++) {
+            months[index].classList.remove("startRange");
+            months[index].classList.remove("inRange");
+            months[index].classList.remove("endRange");
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This pull request fixes the following issue: https://github.com/flatpickr/flatpickr/issues/2769 .

When selecting a range of months with the Month Select plugin and 'closeOnSelect: disabled', the visual glitch where three months can be highlighted is fixed.