### PR TITLE
Add ar-sy localization

### DIFF
--- a/src/l10n/ar-sy.ts
+++ b/src/l10n/ar-sy.ts
@@ -1,0 +1,61 @@
+/**
+ * Syrian Arabic locals for flatpickr, also included others local in the region: Lebanon, Jordan, Palestine and Iraq
+ * source (en): https://en.wikipedia.org/wiki/Assyrian_calendar
+ * source (ar): https://ar.wikipedia.org/wiki/شهور_سريانية
+ */
+import { CustomLocale } from "../types/locale";
+import { FlatpickrFn } from "../types/instance";
+
+const fp =
+  typeof window !== "undefined" && window.flatpickr !== undefined
+    ? window.flatpickr
+    : ({
+      l10ns: {},
+    } as FlatpickrFn);
+
+export const SyrianArabic: CustomLocale = {
+  weekdays: {
+    shorthand: ["أحد", "اثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت"],
+    longhand: [
+      "الأحد",
+      "الاثنين",
+      "الثلاثاء",
+      "الأربعاء",
+      "الخميس",
+      "الجمعة",
+      "السبت",
+    ],
+  },
+
+  months: {
+    shorthand: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
+    longhand: [
+      "كانون الثاني",
+      "شباط",
+      "آذار",
+      "نيسان",
+      " أيار",
+      "حزيران",
+      "تموز",
+      "آب",
+      "أيلول",
+      "تشرين الأول",
+      "تشرين الثاني",
+      "كانون الأول",
+    ],
+  },
+  firstDayOfWeek: 0,
+  rangeSeparator: " إلى ",
+  weekAbbreviation: "Wk",
+  scrollTitle: "قم بالتمرير للزيادة",
+  toggleTitle: "اضغط للتبديل",
+  yearAriaLabel: "سنة",
+  monthAriaLabel: "شهر",
+  hourAriaLabel: "ساعة",
+  minuteAriaLabel: "دقيقة",
+  time_24hr: true,
+};
+
+fp.l10ns.ar = SyrianArabic;
+
+export default fp.l10ns;

--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -1,6 +1,7 @@
 import { key, CustomLocale } from "../types/locale";
 
 import { Arabic as ar } from "./ar";
+import { SyrianArabic as ar_sy } from "./ar-sy";
 import { Austria as at } from "./at";
 import { Azerbaijan as az } from "./az";
 import { Belarusian as be } from "./be";
@@ -66,6 +67,7 @@ import { MandarinTraditional as zhTw } from "./zh_tw";
 
 const l10n: Record<key, CustomLocale> = {
   ar,
+  ar_sy,
   at,
   az,
   be,

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -113,6 +113,7 @@ export type CustomLocale = {
 
 export type key =
   | "ar"
+  | "ar_sy"
   | "at"
   | "az"
   | "be"


### PR DESCRIPTION
Add Syrian Arabic Localisation

In Iraq and Levant region the name of Gregorian months are diffreant that other Arabic speaker countries

https://en.wikipedia.org/wiki/Assyrian_calendar