### PR TITLE
Can alter date for display, formatting and parsing using a and A token.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ function FlatpickrInstance(
    */
   function onYearInput(event: KeyboardEvent & IncrementEvent) {
     const eventTarget = getEventTarget(event) as HTMLInputElement;
-    const year = parseInt(eventTarget.value) + (event.delta || 0);
+    const year = parseInt(eventTarget.value) + (event.delta || 0) - self.config.alterYear;
 
     if (
       year / 1000 > 1 ||
@@ -2794,7 +2794,7 @@ function FlatpickrInstance(
         self.monthsDropdownContainer.value = d.getMonth().toString();
       }
 
-      yearElement.value = d.getFullYear().toString();
+      yearElement.value = (d.getFullYear() + self.config.alterYear).toString();
     });
 
     self._hidePrevMonthArrow =

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -266,6 +266,9 @@ Use it along with "enableTime" to create a time picker. */
 
   /* See https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements */
   wrap: boolean;
+
+  /* add year before display */
+  alterYear: number;
 }
 
 export type Options = Partial<BaseOptions>;
@@ -339,6 +342,7 @@ export interface ParsedOptions {
   time_24hr: boolean;
   weekNumbers: boolean;
   wrap: boolean;
+  alterYear: number;
 }
 
 export const defaults: ParsedOptions = {
@@ -421,4 +425,5 @@ export const defaults: ParsedOptions = {
   time_24hr: false,
   weekNumbers: false,
   wrap: false,
+  alterYear: 0,
 };

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -106,7 +106,7 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
 
       ops.forEach(
         ({ fn, val }) =>
-          (parsedDate = fn(parsedDate as Date, val, locale) || parsedDate)
+          (parsedDate = fn(parsedDate as Date, val, locale, config) || parsedDate)
       );
 
       parsedDate = matched ? parsedDate : undefined;


### PR DESCRIPTION
Because I need to display Buddhist era and I really like Flatpickr.

Add option 'alterYear' to modify displaying year in year input.
Can display modified year using token 'a' for two digits and 'A' for 4 digit padded year in date format and parse.
