### PR TITLE
Fix: export Irish locale as 'ga' instead of 'hr'.

### DIFF
--- a/src/l10n/ga.ts
+++ b/src/l10n/ga.ts
@@ -58,6 +58,6 @@ export const Irish: CustomLocale = {
   time_24hr: true,
 };
 
-fp.l10ns.hr = Irish;
+fp.l10ns.ga = Irish;
 
 export default fp.l10ns;

--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -21,6 +21,7 @@ import { Persian as fa } from "./fa";
 import { Finnish as fi } from "./fi";
 import { Faroese as fo } from "./fo";
 import { French as fr } from "./fr";
+import { Irish as ga } from "./ga";
 import { Greek as gr } from "./gr";
 import { Hebrew as he } from "./he";
 import { Hindi as hi } from "./hi";
@@ -88,6 +89,7 @@ const l10n: Record<key, CustomLocale> = {
   fi,
   fo,
   fr,
+  ga,
   gr,
   he,
   hi,

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -16,7 +16,7 @@ export type Locale = {
       string,
       string,
       string,
-      string
+      string,
     ];
     longhand: [
       string,
@@ -30,7 +30,7 @@ export type Locale = {
       string,
       string,
       string,
-      string
+      string,
     ];
   };
   daysInMonth: [
@@ -45,7 +45,7 @@ export type Locale = {
     number,
     number,
     number,
-    number
+    number,
   ];
   firstDayOfWeek: number;
   ordinal: (nth: number) => string;
@@ -92,7 +92,7 @@ export type CustomLocale = {
       string,
       string,
       string,
-      string
+      string,
     ];
     longhand: [
       string,
@@ -106,7 +106,7 @@ export type CustomLocale = {
       string,
       string,
       string,
-      string
+      string,
     ];
   };
 };
@@ -135,6 +135,7 @@ export type key =
   | "fi"
   | "fo"
   | "fr"
+  | "ga"
   | "gr"
   | "he"
   | "hi"


### PR DESCRIPTION
The Irish locale was incorrectly exported as 'hr' (Croatian). This fixes it to 'ga'.

Fixes [#2215](https://github.com/flatpickr/flatpickr/issues/2215) (5 years later it's time to fix this simple bug!)

Changes:
- ga.ts: export as 'ga'
- locale.ts: add 'ga' to LocaleKey type
- index.ts: import and export ga